### PR TITLE
M0-03 — AGENTS.md — Manuscript-first quickstart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,33 @@
 - Manuscript-first: every task should move the Quarto manuscript forward; update **AGENTS.md** in the same PR whenever toggles/CLI/workflows change and call it out in the PR body.
 - Baseline reference: `ssrn-3118643.qmd` captures the original Caiani article—consult it when aligning new manuscript sections or validating outputs.
 - Strategic context: see `docs/blueprint.md` for the full manuscript blueprint, planned figures/tables, and Quarto page layout.
+
+## Quickstart — Py2 Sim + Py3 Decider + Quarto
+
+Run these from the repo root; keep the Decider stub in its own terminal while the sim executes.
+
+1. **Start the Decider stub (Python 3).**
+
+   ```bash
+   python3 tools/decider/server.py --stub
+   ```
+
+   - Health check: `curl http://127.0.0.1:8000/healthz` should return `{ "status": "ok" }`.
+   - Logs appear on stdout (and will later mirror into `logs/decider_stub.log`). Leave this process running.
+
+2. **Kick a short baseline run (Python 2).**
+
+   ```bash
+   python2 code/timing.py
+   ```
+
+   - Default parameters cover 1001 ticks; for smoke tests temporarily set `Parameter.ncycle = 200` *locally* (do **not** commit) or switch to the demo runner from #19 once it lands.
+   - Aggregates land in `data/`; runtime notes (and future LLM fallback counts) append to `timing.log`.
+
+3. **Render the Quarto docs.**
+
+   ```bash
+   quarto render docs
+   ```
+
+   - Output site lives under `docs/_site/`; cite figures from `figs/` and tables from `data/` in the manuscript pages.


### PR DESCRIPTION
What & Why
- Add an executor quickstart so newcomers can boot the Decider stub, run the Py2 sim, and render the manuscript site.
- Clarify where smoke-test outputs land, keeping manuscript discipline front and center.

Artifacts
- AGENTS.md

Affected Pages
- AGENTS.md (workflow quickstart added around lines 20-44)

Evidence
- docs-only change (no runtime commands)

Closes #3
