### PR TITLE
M1-01 — Decider server (Py3) — stub mode + /healthz

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -15,6 +15,8 @@ website:
         href: blueprint.md
       - text: "Conventions"
         href: conventions.md
+      - text: "Decider Stub"
+        href: methods/decider.md
 
 format:
   html:

--- a/docs/methods/decider.md
+++ b/docs/methods/decider.md
@@ -1,0 +1,75 @@
+---
+title: "Decider Stub Server"
+date: last-modified
+format:
+  html:
+    toc: true
+    toc-depth: 2
+---
+
+This page describes the local **Decider** stub used during Milestone M1. The Python 3 server runs on localhost and returns deterministic placeholder decisions for the firm, bank, and wage endpoints.
+
+## Start the server
+
+Run the server from the repository root:
+
+```bash
+python3 tools/decider/server.py --stub
+```
+
+- Default bind: `127.0.0.1:8000`. Override with `--host` / `--port` if needed.
+- The process logs requests to stdout. Leave it running while the Python 2 simulation calls it.
+- To verify the binary without keeping it alive, add `--check` (starts the server in the background, hits `/healthz`, prints the result, and exits):
+
+```bash
+python3 tools/decider/server.py --stub --check
+```
+
+## Health endpoint
+
+```bash
+curl -s http://127.0.0.1:8000/healthz | jq
+```
+
+Expected response:
+
+```json
+{
+  "status": "ok"
+}
+```
+
+## Stub decision endpoints
+
+The stub mode implements three deterministic POST routes. Payloads are accepted but ignored for now; later milestones will replace these with schema validation and live LLM calls.
+
+| Endpoint | Description | Example response |
+| --- | --- | --- |
+| `POST /decide/firm` | Firm pricing & expectations decision | `{ "direction": "hold", "price_step": 0.0, "expectation_bias": 0.0, "explanation": "stub: hold price; baseline heuristic" }` |
+| `POST /decide/bank` | Bank loan approval & spread | `{ "approve": true, "credit_limit_ratio": 1.0, "spread_bps": 150, "explanation": "stub: approve with default spread" }` |
+| `POST /decide/wage` | Worker reservation / firm wage offer | `{ "direction": "hold", "wage_step": 0.0, "explanation": "stub: no wage adjustment" }` |
+
+Example call (firm endpoint):
+
+```bash
+curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"inventory": 100, "backlog": 5}' \
+  http://127.0.0.1:8000/decide/firm
+```
+
+_Response (line-wrapped for readability):_
+
+```json
+{"direction": "hold", "price_step": 0.0, "expectation_bias": 0.0, "explanation": "stub: hold price; baseline heuristic"}
+```
+
+## Roadmap
+
+Upcoming M1 issues extend this stub:
+
+1. **M1-02 (Schemas):** JSON schema validation and friendly error messages.
+2. **M1-03 (Cache):** Deterministic cache keyed by state hash.
+3. **M1-04 (Timeout/Budget):** Server-side deadline and per-tick call budget enforcement.
+
+Each addition will update this page so the quickstart in `AGENTS.md` always points to accurate instructions.

--- a/tools/decider/server.py
+++ b/tools/decider/server.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Local Decider stub server.
+
+This module exposes a minimal HTTP server that mimics the future LLM-powered
+"Decider" microservice.  For Milestone M1-01 we only implement deterministic
+stub responses and a `/healthz` endpoint; later milestones will extend this file
+with schema validation, caching, and timeouts.
+
+Usage (from the repo root):
+
+    python3 tools/decider/server.py --stub
+
+Optional flags:
+    --host / --port   Bind address (defaults to 127.0.0.1:8000)
+    --log-level       Python logging level (defaults to INFO)
+    --check           Boot the server, hit /healthz once, print the status, exit
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import logging
+import signal
+import threading
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Dict, Optional, Tuple
+
+LOGGER = logging.getLogger("decider.server")
+
+STUB_RESPONSES: Dict[str, Dict[str, Any]] = {
+    "/decide/firm": {
+        "direction": "hold",
+        "price_step": 0.0,
+        "expectation_bias": 0.0,
+        "explanation": "stub: hold price; baseline heuristic"
+    },
+    "/decide/bank": {
+        "approve": True,
+        "credit_limit_ratio": 1.0,
+        "spread_bps": 150,
+        "explanation": "stub: approve with default spread"
+    },
+    "/decide/wage": {
+        "direction": "hold",
+        "wage_step": 0.0,
+        "explanation": "stub: no wage adjustment"
+    },
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Local Decider stub server")
+    parser.add_argument("--host", default="127.0.0.1", help="Bind host (default: 127.0.0.1)")
+    parser.add_argument("--port", type=int, default=8000, help="Bind port (default: 8000)")
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
+        help="Logging verbosity"
+    )
+    parser.add_argument(
+        "--stub",
+        action="store_true",
+        help="Serve deterministic stub responses (default behaviour)."
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Run a one-shot health check and exit."
+    )
+    args = parser.parse_args()
+
+    # `--stub` is the only supported mode today; default to True so users do not
+    # have to pass the flag explicitly once the CLI stabilises.
+    if not args.stub:
+        LOGGER.debug("--stub not provided; enabling stub mode by default")
+        args.stub = True
+    return args
+
+
+def make_handler(stub_mode: bool):
+    """Factory that builds a request handler bound to the configuration."""
+
+    class DeciderRequestHandler(BaseHTTPRequestHandler):
+        server_version = "DeciderStub/0.1"
+
+        def log_message(self, fmt: str, *args: Any) -> None:  # pragma: no cover - delegated to logging
+            LOGGER.info("%s - %s", self.address_string(), fmt % args)
+
+        def _read_json(self) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+            length = int(self.headers.get("Content-Length", 0))
+            if length <= 0:
+                return {}, None
+            try:
+                data = self.rfile.read(length)
+            except Exception as exc:  # pragma: no cover - rare I/O failure
+                return None, f"failed to read request body: {exc}"
+            try:
+                return json.loads(data.decode("utf-8")), None
+            except json.JSONDecodeError as exc:
+                return None, f"invalid JSON payload: {exc}"
+
+        def _send_json(self, status: HTTPStatus, payload: Dict[str, Any]) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self) -> None:  # noqa: N802 (HTTP verb name)
+            if self.path == "/healthz":
+                LOGGER.debug("health check hit")
+                self._send_json(HTTPStatus.OK, {"status": "ok"})
+            else:
+                LOGGER.debug("unknown GET path %s", self.path)
+                self._send_json(HTTPStatus.NOT_FOUND, {"error": "not_found", "path": self.path})
+
+        def do_POST(self) -> None:  # noqa: N802 (HTTP verb name)
+            LOGGER.debug("POST %s", self.path)
+            payload, error = self._read_json()
+            if error:
+                LOGGER.warning("invalid payload: %s", error)
+                self._send_json(HTTPStatus.BAD_REQUEST, {"error": "invalid_json", "detail": error})
+                return
+
+            if not stub_mode:
+                LOGGER.error("non-stub mode requested but not implemented")
+                self._send_json(
+                    HTTPStatus.NOT_IMPLEMENTED,
+                    {"error": "not_implemented", "detail": "only stub mode is available"}
+                )
+                return
+
+            response = STUB_RESPONSES.get(self.path)
+            if response is None:
+                LOGGER.warning("unknown path: %s", self.path)
+                self._send_json(HTTPStatus.NOT_FOUND, {"error": "unknown_endpoint", "path": self.path})
+                return
+
+            LOGGER.info("stub response for %s", self.path)
+            # Return a copy so callers cannot mutate the global template.
+            self._send_json(HTTPStatus.OK, json.loads(json.dumps(response)))
+
+    return DeciderRequestHandler
+
+
+def run_server(host: str, port: int, stub_mode: bool, check_only: bool) -> int:
+    server = ThreadingHTTPServer((host, port), make_handler(stub_mode))
+    LOGGER.info("Decider stub listening on http://%s:%s", host, port)
+
+    # Graceful shutdown support for Ctrl+C / SIGTERM.
+    def _handle_stop(signum: int, _frame: Any) -> None:  # pragma: no cover - signal path
+        LOGGER.info("Received signal %s, shutting down", signum)
+        server.shutdown()
+
+    signal.signal(signal.SIGINT, _handle_stop)
+    signal.signal(signal.SIGTERM, _handle_stop)
+
+    if check_only:
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            conn = http.client.HTTPConnection(host, port, timeout=3)
+            conn.request("GET", "/healthz")
+            resp = conn.getresponse()
+            status = resp.status
+            body = resp.read().decode("utf-8")
+            LOGGER.info("Health check status=%s body=%s", status, body)
+            ok = status == HTTPStatus.OK
+        except Exception as exc:  # pragma: no cover - network failures
+            LOGGER.error("Health check failed: %s", exc)
+            ok = False
+        finally:
+            server.shutdown()
+            thread.join(timeout=2)
+        return 0 if ok else 1
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:  # pragma: no cover - handled by signal
+        LOGGER.info("Interrupted by user")
+    finally:
+        server.server_close()
+    return 0
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(level=getattr(logging, args.log_level.upper()), format="%(asctime)s %(levelname)s %(message)s")
+    exit_code = run_server(args.host, args.port, stub_mode=args.stub, check_only=args.check)
+    raise SystemExit(exit_code)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
What & Why
- Introduce the Python 3 Decider stub so Py2 clients have a localhost target during M1.
- Document how to start the stub, hit `/healthz`, and inspect deterministic responses.

Artifacts
- tools/decider/server.py
- docs/methods/decider.md

Affected Pages
- docs/_quarto.yml (navbar)
- docs/methods/decider.md

Evidence
- `python3 tools/decider/server.py --stub --check --port 8123`
- `quarto render docs`

Closes #7
