### PR TITLE
M1-02 — Decision schemas (firm, bank, wage)

### DIFF
--- a/docs/methods/decider.md
+++ b/docs/methods/decider.md
@@ -7,7 +7,7 @@ format:
     toc-depth: 2
 ---
 
-This page describes the local **Decider** stub used during Milestone M1. The Python 3 server runs on localhost and returns deterministic placeholder decisions for the firm, bank, and wage endpoints.
+This page describes the local **Decider** stub used during Milestone M1. The Python 3 server runs on localhost and returns deterministic placeholder decisions for the firm, bank, and wage endpoints while enforcing request validation via JSON Schemas.
 
 ## Start the server
 
@@ -41,7 +41,7 @@ Expected response:
 
 ## Stub decision endpoints
 
-The stub mode implements three deterministic POST routes. Payloads are accepted but ignored for now; later milestones will replace these with schema validation and live LLM calls.
+The stub mode implements three deterministic `POST` routes. Each endpoint expects a JSON payload that matches the schema stored under `tools/decider/schemas_*.json`. The schemas only require the fields we know the Py2 simulation can emit (for example `firm_id`, `tick`, the baseline numeric decision, and the guard bounds when available). When a payload is malformed the server replies with **HTTP 400** plus a list of validation errors.
 
 | Endpoint | Description | Example response |
 | --- | --- | --- |
@@ -54,7 +54,29 @@ Example call (firm endpoint):
 ```bash
 curl -s -X POST \
   -H "Content-Type: application/json" \
-  -d '{"inventory": 100, "backlog": 5}' \
+  -d '{
+    "request_id": "demo-001",
+    "tick": 42,
+    "firm_id": 7,
+    "state": {
+      "price": 1.05,
+      "unit_cost": 0.98,
+      "inventory": 120,
+      "backlog": 4
+    },
+    "bounds": {
+      "price_step_min": 0.0,
+      "price_step_max": 0.04,
+      "expectation_bias_min": -0.1,
+      "expectation_bias_max": 0.1,
+      "price_floor": 0.95
+    },
+    "baseline": {
+      "direction": "hold",
+      "price_step": 0.0,
+      "expectation_bias": 0.0
+    }
+  }' \
   http://127.0.0.1:8000/decide/firm
 ```
 
@@ -62,6 +84,38 @@ _Response (line-wrapped for readability):_
 
 ```json
 {"direction": "hold", "price_step": 0.0, "expectation_bias": 0.0, "explanation": "stub: hold price; baseline heuristic"}
+```
+
+### Schema validation & friendly errors
+
+Missing or mistyped fields trigger a structured error. Example (payload omits `firm_id`):
+
+```bash
+curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"request_id": "oops", "tick": 2, "state": {}, "bounds": {}, "baseline": {}}' \
+  http://127.0.0.1:8000/decide/firm | jq
+```
+
+```json
+{
+  "error": "invalid_payload",
+  "messages": [
+    "payload.firm_id is required",
+    "payload.state.price is required",
+    "payload.state.unit_cost is required",
+    "payload.state.inventory is required",
+    "payload.state.backlog is required",
+    "payload.bounds.price_step_min is required",
+    "payload.bounds.price_step_max is required",
+    "payload.bounds.expectation_bias_min is required",
+    "payload.bounds.expectation_bias_max is required",
+    "payload.bounds.price_floor is required",
+    "payload.baseline.direction is required",
+    "payload.baseline.price_step is required",
+    "payload.baseline.expectation_bias is required"
+  ]
+}
 ```
 
 ## Roadmap

--- a/tools/decider/schemas_bank.json
+++ b/tools/decider/schemas_bank.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "BankDecisionRequest",
+  "type": "object",
+  "required": [
+    "request_id",
+    "tick",
+    "bank_id",
+    "borrower_id",
+    "application",
+    "baseline"
+  ],
+  "properties": {
+    "request_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tick": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "bank_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "borrower_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "application": {
+      "type": "object",
+      "required": [
+        "requested_credit",
+        "current_leverage",
+        "liquidity_ratio",
+        "capital_ratio"
+      ],
+      "properties": {
+        "requested_credit": {"type": "number"},
+        "current_leverage": {"type": "number"},
+        "liquidity_ratio": {"type": "number"},
+        "capital_ratio": {"type": "number"},
+        "collateral_value": {"type": "number"},
+        "sector": {"type": "string"}
+      },
+      "additionalProperties": true
+    },
+    "bounds": {
+      "type": "object",
+      "properties": {
+        "spread_bps_min": {"type": "integer"},
+        "spread_bps_max": {"type": "integer"},
+        "credit_limit_ratio_min": {"type": "number"},
+        "credit_limit_ratio_max": {"type": "number"}
+      },
+      "additionalProperties": true
+    },
+    "baseline": {
+      "type": "object",
+      "required": [
+        "approve",
+        "credit_limit_ratio",
+        "spread_bps"
+      ],
+      "properties": {
+        "approve": {"type": "boolean"},
+        "credit_limit_ratio": {"type": "number"},
+        "spread_bps": {"type": "integer"}
+      },
+      "additionalProperties": false
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/tools/decider/schemas_firm.json
+++ b/tools/decider/schemas_firm.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "FirmDecisionRequest",
+  "type": "object",
+  "required": [
+    "request_id",
+    "tick",
+    "firm_id",
+    "state",
+    "baseline"
+  ],
+  "properties": {
+    "request_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tick": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "firm_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "state": {
+      "type": "object",
+      "required": [
+        "price",
+        "unit_cost",
+        "inventory",
+        "backlog"
+      ],
+      "properties": {
+        "price": {"type": "number"},
+        "unit_cost": {"type": "number"},
+        "inventory": {"type": "number"},
+        "backlog": {"type": "number"},
+        "expected_demand": {"type": "number"},
+        "target_inventory": {"type": "number"}
+      },
+      "additionalProperties": true
+    },
+    "bounds": {
+      "type": "object",
+      "properties": {
+        "price_step_min": {"type": "number"},
+        "price_step_max": {"type": "number"},
+        "expectation_bias_min": {"type": "number"},
+        "expectation_bias_max": {"type": "number"},
+        "price_floor": {"type": "number"}
+      },
+      "additionalProperties": true
+    },
+    "baseline": {
+      "type": "object",
+      "required": [
+        "direction",
+        "price_step",
+        "expectation_bias"
+      ],
+      "properties": {
+        "direction": {
+          "type": "string",
+          "enum": [
+            "up",
+            "down",
+            "hold"
+          ]
+        },
+        "price_step": {"type": "number"},
+        "expectation_bias": {"type": "number"}
+      },
+      "additionalProperties": false
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/tools/decider/schemas_wage.json
+++ b/tools/decider/schemas_wage.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "WageDecisionRequest",
+  "type": "object",
+  "required": [
+    "request_id",
+    "tick",
+    "actor",
+    "agent_id",
+    "state",
+    "baseline"
+  ],
+  "properties": {
+    "request_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tick": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "actor": {
+      "type": "string",
+      "enum": [
+        "worker",
+        "firm"
+      ]
+    },
+    "agent_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "state": {
+      "type": "object",
+      "required": [
+        "current_wage",
+        "target_wage"
+      ],
+      "properties": {
+        "current_wage": {"type": "number"},
+        "target_wage": {"type": "number"},
+        "vacancy_rate": {"type": "number"},
+        "unemployment_rate": {"type": "number"},
+        "productivity": {"type": "number"}
+      },
+      "additionalProperties": true
+    },
+    "bounds": {
+      "type": "object",
+      "properties": {
+        "wage_step_min": {"type": "number"},
+        "wage_step_max": {"type": "number"}
+      },
+      "additionalProperties": true
+    },
+    "baseline": {
+      "type": "object",
+      "required": [
+        "direction",
+        "wage_step"
+      ],
+      "properties": {
+        "direction": {
+          "type": "string",
+          "enum": [
+            "up",
+            "down",
+            "hold"
+          ]
+        },
+        "wage_step": {"type": "number"}
+      },
+      "additionalProperties": false
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
What & Why
- Introduce JSON Schemas for firm/bank/wage requests and validate incoming payloads in the Decider stub.
- Document the required fields and show failure messages so Py2 callers can debug malformed requests quickly.

Artifacts
- tools/decider/schemas_firm.json
- tools/decider/schemas_bank.json
- tools/decider/schemas_wage.json

Affected Pages
- docs/methods/decider.md (new validation section and updated examples)

Evidence
- `python3 tools/decider/server.py --stub --check --port 8130`
- `python3 - <<'PY' …` (inline validation harness demonstrating HTTP 400 output)
- `quarto render docs`

Closes #8
