### PR TITLE
M1-05 — Py2 HTTP client

### DIFF
--- a/code/llm_bridge_client.py
+++ b/code/llm_bridge_client.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+"""HTTP client for the local Decider service (Python 2).
+
+This module provides a minimal wrapper around ``urllib2`` so the legacy Caiani
+simulation (Python 2) can talk to the Python 3 Decider server.  The client
+exposes helper methods for the three decision endpoints and surfaces a tuple of
+``(response_dict, error_info)`` to the caller.  ``response_dict`` is returned on
+HTTP 200 with valid JSON; otherwise ``None`` is returned together with a short
+error descriptor that the simulation can log before falling back to the baseline
+heuristic.
+"""
+
+from __future__ import absolute_import
+
+import json
+import logging
+import socket
+import urllib2
+
+LOGGER = logging.getLogger(__name__)
+
+try:  # Python 2 only
+    text_type = unicode  # type: ignore  # noqa: F821 - defined at runtime
+except NameError:  # pragma: no cover - Python 3 fallback for tooling
+    text_type = str
+
+try:
+    bytes_type = bytes
+except NameError:  # pragma: no cover - legacy Python fallback
+    bytes_type = str
+
+_DECISION_ENDPOINTS = {
+    'firm': '/decide/firm',
+    'bank': '/decide/bank',
+    'wage': '/decide/wage',
+}
+
+
+class LLMBridgeClient(object):
+    """Minimal HTTP client for the Decider stub/live service."""
+
+    def __init__(self, base_url, timeout=0.2, headers=None):
+        if not base_url:
+            raise ValueError('base_url is required')
+        # Normalise whitespace and trailing slashes so path joins are predictable.
+        base_url = base_url.strip()
+        if base_url.endswith('/'):
+            base_url = base_url[:-1]
+        self.base_url = base_url
+        self.timeout = float(timeout) if timeout is not None else None
+        self.headers = {'Content-Type': 'application/json'}
+        if headers:
+            self.headers.update(headers)
+
+    def decide_firm(self, payload):
+        """Call the firm endpoint.
+
+        Returns ``(response_dict, error_info)``.
+        """
+
+        return self._post_json(_DECISION_ENDPOINTS['firm'], payload)
+
+    def decide_bank(self, payload):
+        """Call the bank endpoint (loan approval & spread)."""
+
+        return self._post_json(_DECISION_ENDPOINTS['bank'], payload)
+
+    def decide_wage(self, payload):
+        """Call the wage endpoint (worker reservation / firm offer)."""
+
+        return self._post_json(_DECISION_ENDPOINTS['wage'], payload)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _post_json(self, path, payload):
+        """POST ``payload`` (dict) to ``path`` and return ``(data, error)``.
+
+        ``data`` is a Python object parsed from JSON when the response is 200
+        and well-formed.  Otherwise ``None`` is returned along with ``error``, a
+        dict containing at least a ``reason`` key.  The caller can log this and
+        fall back to the baseline decision logic.
+        """
+
+        if not isinstance(payload, dict):
+            raise TypeError('payload must be a dict (got %r)' % type(payload))
+
+        url = self._build_url(path)
+        data = json.dumps(payload)
+        request = urllib2.Request(url, data=data, headers=self.headers)
+
+        try:
+            response = urllib2.urlopen(request, timeout=self.timeout)
+        except urllib2.HTTPError as exc:
+            error_body = exc.read()
+            parsed = self._safe_json(error_body)
+            return None, {
+                'reason': 'http_error',
+                'status': exc.code,
+                'body': parsed,
+            }
+        except urllib2.URLError as exc:
+            # ``URLError`` wraps a variety of socket issues.  Timeouts may be
+            # surfaced either as ``socket.timeout`` or via ``str(reason)``.
+            if isinstance(exc.reason, socket.timeout):
+                return None, self._timeout_error(url)
+            return None, {
+                'reason': 'connection_error',
+                'detail': str(exc.reason),
+            }
+        except socket.timeout:
+            return None, self._timeout_error(url)
+        except Exception as exc:  # pragma: no cover - defensive catch-all
+            return None, {
+                'reason': 'unexpected_error',
+                'detail': str(exc),
+            }
+
+        status = getattr(response, 'code', None) or response.getcode()
+        body = response.read()
+        if status != 200:
+            parsed = self._safe_json(body)
+            return None, {
+                'reason': 'http_error',
+                'status': status,
+                'body': parsed,
+            }
+
+        try:
+            text = self._ensure_text(body)
+            return json.loads(text), None
+        except ValueError as exc:
+            return None, {
+                'reason': 'decode_error',
+                'detail': 'invalid JSON response: %s' % exc,
+            }
+
+    def _build_url(self, path):
+        if not path:
+            raise ValueError('path is required')
+        if not path.startswith('/'):
+            path = '/' + path
+        return self.base_url + path
+
+    @staticmethod
+    def _safe_json(raw_body):
+        if raw_body is None:
+            return None
+        try:
+            text = LLMBridgeClient._ensure_text(raw_body)
+            return json.loads(text)
+        except (TypeError, ValueError):
+            return raw_body
+
+    @staticmethod
+    def _ensure_text(raw):
+        if isinstance(raw, text_type):
+            return raw
+        if isinstance(raw, bytes_type):
+            try:
+                return raw.decode('utf-8')
+            except AttributeError:
+                return raw
+        return raw
+
+    @staticmethod
+    def _timeout_error(url):
+        return {
+            'reason': 'timeout',
+            'detail': 'request to %s exceeded the configured timeout' % url,
+        }
+
+
+__all__ = ['LLMBridgeClient']

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -17,6 +17,8 @@ website:
         href: conventions.md
       - text: "Decider Stub"
         href: methods/decider.md
+      - text: "Py2 Client"
+        href: methods/py2_client.md
 
 format:
   html:

--- a/docs/methods/py2_client.md
+++ b/docs/methods/py2_client.md
@@ -1,0 +1,95 @@
+---
+title: "Python 2 HTTP client"
+date: last-modified
+format:
+  html:
+    toc: true
+    toc-depth: 2
+---
+
+This page documents the **Python 2** client that calls the local Decider service. The legacy Caiani simulation stays in Python 2, so we ship a thin wrapper around ``urllib2`` that knows how to talk to the Python 3 server, parse JSON, and signal when the caller should fall back to the baseline heuristic.
+
+## Quickstart
+
+```python
+from code.llm_bridge_client import LLMBridgeClient
+
+client = LLMBridgeClient("http://127.0.0.1:8000", timeout=0.2)
+state = {"inventory": 120, "backlog": 6}
+
+decision, error = client.decide_firm(state)
+if decision is None:
+    # Baseline fallback path: log the reason, keep legacy heuristic.
+    LOGGER.warning("firm LLM fallback: %s", error)
+    apply_baseline_firm_rule(state)
+else:
+    apply_llm_firm_rule(decision)
+```
+
+- The client normalises the base URL (trims trailing slashes) and sets the ``Content-Type: application/json`` header for every request.
+- ``timeout`` defaults to ``0.2`` seconds (200 ms) to match the M1 run logistics agreement. Pass ``None`` to use the ``urllib2`` global default.
+- Every call returns ``(decision_dict, error_info)``. When ``decision_dict`` is ``None`` you *must* fall back to the legacy baseline rule.
+
+## Available helpers
+
+| Method | Endpoint | Notes |
+| --- | --- | --- |
+| ``decide_firm(payload)`` | ``POST /decide/firm`` | Pricing & expectations decision |
+| ``decide_bank(payload)`` | ``POST /decide/bank`` | Loan approval + spread (basis points) |
+| ``decide_wage(payload)`` | ``POST /decide/wage`` | Worker reservation / firm offer |
+
+Each helper validates that ``payload`` is a ``dict`` and serialises it with ``json.dumps`` before issuing the POST.
+
+## Error signalling
+
+When a request fails, ``None`` is returned along with a short diagnostic dictionary. The caller is responsible for logging it (or counting for telemetry) before taking the baseline path. The ``reason`` field is always present:
+
+| Reason | Trigger | Extra fields |
+| --- | --- | --- |
+| ``timeout`` | Socket timeout (client side) | ``detail``: string message |
+| ``connection_error`` | ``urllib2.URLError`` other than timeout | ``detail``: string message |
+| ``http_error`` | HTTP status other than 200 | ``status`` (int), ``body`` (parsed JSON or raw string) |
+| ``decode_error`` | Response body not valid JSON | ``detail``: string message |
+| ``unexpected_error`` | Catch-all for any other exception | ``detail``: string message |
+
+Example handling:
+
+```python
+payload = {"leverage": 3.2, "credit_request": 100.0}
+decision, error = client.decide_bank(payload)
+if decision is None:
+    # Tell the logs that we hit the fallback path.
+    LOGGER.info("bank LLM fallback (%s): %s", error['reason'], error.get('detail'))
+    approve, spread = baseline_bank_decision(payload)
+else:
+    approve = decision.get("approve", False)
+    spread = decision.get("spread_bps", 150)
+```
+
+The helper methods never raise on network failures so the simulation can keep running; only programmer errors (e.g., passing a non-dict payload) raise immediately.
+
+## Local testing recipe
+
+1. Start the Decider stub in another terminal:
+
+   ```bash
+   python3 tools/decider/server.py --stub
+   ```
+
+2. Run a short Python 2 REPL snippet:
+
+   ```python
+   >>> from code.llm_bridge_client import LLMBridgeClient
+   >>> client = LLMBridgeClient("http://127.0.0.1:8000")
+   >>> client.decide_wage({"unemployment": 0.04})
+   ({'direction': 'hold', 'wage_step': 0.0, 'explanation': 'stub: no wage adjustment'}, None)
+   ```
+
+3. Stop the server and re-run the call to see the fallback output:
+
+   ```python
+   >>> client.decide_wage({"unemployment": 0.04})
+   (None, {'reason': 'connection_error', 'detail': '[Errno 111] Connection refused'})
+   ```
+
+When you wire the client into the simulation, keep the tuples intact so the fallback logic can log the reason (timeout vs HTTP error vs invalid JSON) before applying the baseline heuristic.


### PR DESCRIPTION
## What
- add urllib2-based client returning (decision, error) tuples with reason codes
- document client usage and fallback handling in docs/methods/py2_client.md and link in navbar

## Why
- Py2 sim needs a minimal bridge to call the Decider while cleanly signalling when to fall back

## Testing
- python2 -m py_compile code/llm_bridge_client.py
- quarto render docs

Closes #11