### PR TITLE
M1-06 — parameter.py toggles & logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,3 +49,10 @@ Run these from the repo root; keep the Decider stub in its own terminal while th
    ```
 
    - Output site lives under `docs/_site/`; cite figures from `figs/` and tables from `data/` in the manuscript pages.
+
+### LLM toggles & defaults
+- All toggles live in `code/parameter.py`. Defaults keep the legacy heuristics (`use_llm_* = False`).
+- `Parameter.llm_server_url` → default `http://127.0.0.1:8000` (matches the stub server).
+- `Parameter.llm_timeout_ms` → default `200` (ms); convert to seconds for the Py2 client (`timeout = ms / 1000.0`).
+- `Parameter.llm_batch` → default `False`; batch mode is a future milestone, leave off for now.
+- On every run `code/timing.py` appends the current toggle state to `timing.log` (and prints it to stdout) so artifacts show which configuration produced them.

--- a/code/parameter.py
+++ b/code/parameter.py
@@ -14,6 +14,13 @@ class Parameter:
           lastrun=49#
           self.Lrun=range(firstrun,lastrun+1)
           self.weSeedRun='yes'      
+          # LLM bridge configuration (defaults keep legacy heuristics)
+          self.use_llm_firm_pricing = False
+          self.use_llm_bank_credit = False
+          self.use_llm_wage = False
+          self.llm_server_url = 'http://127.0.0.1:8000'
+          self.llm_timeout_ms = 200
+          self.llm_batch = False
           # space and time
           self.ncycle=1001
           self.ncountry=5 #(K)

--- a/code/timing.py
+++ b/code/timing.py
@@ -27,6 +27,7 @@ from aggregator import *
 #from aggregatorAle import *
 from time import *
 import random
+import os
 from bank import *
 from matchingCredit import *
 from matchingBonds import *
@@ -36,9 +37,42 @@ from printParameters import *
 from centralBankUnion import *
 from policy import *
 
+
+_LOG_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'timing.log'))
+
+
+def _flag(value):
+    return 'on' if value else 'off'
+
+
+def log_llm_toggles(parameter):
+    """Append the current LLM toggle configuration to timing.log."""
+
+    timestamp = strftime('%Y-%m-%d %H:%M:%S', localtime())
+    line = (
+        '[%s] LLM toggles server=%s timeout_ms=%s batch=%s firm=%s bank=%s wage=%s\n'
+        % (
+            timestamp,
+            parameter.llm_server_url,
+            parameter.llm_timeout_ms,
+            _flag(parameter.llm_batch),
+            _flag(parameter.use_llm_firm_pricing),
+            _flag(parameter.use_llm_bank_credit),
+            _flag(parameter.use_llm_wage),
+        )
+    )
+    try:
+        handle = open(_LOG_PATH, 'a')
+        handle.write(line)
+        handle.close()
+    except Exception as exc:
+        print 'Warning: failed to write LLM toggle log (%s)' % exc
+    print line.strip()
+
 # parameter
 para=Parameter()
 para.directory()
+log_llm_toggles(para)
 printPa=PrintParameters(para.name,para.folder)
 
 for run in para.Lrun:

--- a/docs/snippets/signoff_prompt_M0-06.md
+++ b/docs/snippets/signoff_prompt_M0-06.md
@@ -55,7 +55,7 @@ The table above is drawn from `data/_examples/sample_metrics.csv`; future Quarto
 
 ## Ethics & scope
 
-{{< include snippets/ethics_scope.md >}}
+{{< include ethics_scope.md >}}
 ```
 
 ### 3. Ethics & scope disclaimer (docs/snippets/ethics_scope.md)


### PR DESCRIPTION
## What
- add LLM toggle defaults to  and normalize the base URL/timeout config
- log the toggle state to  on startup so runs capture configuration
- document defaults in  and fix the sign-off snippet include so docs render cleanly

## Why
- part of the Live LLM bridge scaffold: keep legacy behaviour by default while exposing the knobs and recording them in logs

## Testing
- python2 -m py_compile code/parameter.py code/timing.py
- quarto render docs

Closes #12