### PR TITLE
M1-02 — Decision schemas (firm, bank, wage)

### DIFF
--- a/tools/decider/schemas/bank_request.schema.json
+++ b/tools/decider/schemas/bank_request.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Bank credit decision request",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "run_id",
+    "tick",
+    "bank_id",
+    "country_id",
+    "capital",
+    "loan_supply",
+    "reserves",
+    "loan_book_value",
+    "deposits",
+    "non_allocated_money",
+    "borrower",
+    "guards"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["1.0"]
+    },
+    "run_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "tick": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "bank_id": {
+      "type": "string",
+      "pattern": "^B\\d+n\\d+$"
+    },
+    "country_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "capital": {
+      "type": "number"
+    },
+    "loan_supply": {
+      "type": "number"
+    },
+    "reserves": {
+      "type": "number"
+    },
+    "loan_book_value": {
+      "type": "number"
+    },
+    "deposits": {
+      "type": "number"
+    },
+    "non_allocated_money": {
+      "type": "number"
+    },
+    "borrower": {
+      "type": "object",
+      "required": [
+        "firm_id",
+        "country_id",
+        "loan_request",
+        "leverage",
+        "relative_productivity",
+        "profit_rate"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "firm_id": {
+          "type": "string",
+          "pattern": "^F\\d+n\\d+$"
+        },
+        "country_id": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "loan_request": {
+          "type": "number"
+        },
+        "leverage": {
+          "type": "number"
+        },
+        "relative_productivity": {
+          "type": "number"
+        },
+        "profit_rate": {
+          "type": "number"
+        }
+      }
+    },
+    "guards": {
+      "type": "object",
+      "required": ["spread_min_bps", "spread_max_bps"],
+      "additionalProperties": false,
+      "properties": {
+        "spread_min_bps": {
+          "type": "number"
+        },
+        "spread_max_bps": {
+          "type": "number"
+        }
+      }
+    }
+  }
+}

--- a/tools/decider/schemas/firm_request.schema.json
+++ b/tools/decider/schemas/firm_request.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Firm pricing & expectations request",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "run_id",
+    "tick",
+    "country_id",
+    "firm_id",
+    "price",
+    "unit_cost",
+    "inventory",
+    "inventory_value",
+    "production_effective",
+    "production_capacity",
+    "sales_last_period",
+    "loan_demand",
+    "loan_received",
+    "net_worth",
+    "expected_wage",
+    "markup",
+    "min_markup",
+    "guards"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["1.0"]
+    },
+    "run_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "tick": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "country_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "firm_id": {
+      "type": "string",
+      "pattern": "^F\\d+n\\d+$"
+    },
+    "tradable": {
+      "type": ["boolean", "null"]
+    },
+    "price": {
+      "type": "number"
+    },
+    "unit_cost": {
+      "type": "number"
+    },
+    "inventory": {
+      "type": "number"
+    },
+    "inventory_value": {
+      "type": "number"
+    },
+    "production_effective": {
+      "type": "number"
+    },
+    "production_capacity": {
+      "type": "number"
+    },
+    "sales_last_period": {
+      "type": "number"
+    },
+    "loan_demand": {
+      "type": "number"
+    },
+    "loan_received": {
+      "type": "number"
+    },
+    "net_worth": {
+      "type": "number"
+    },
+    "expected_wage": {
+      "type": "number"
+    },
+    "markup": {
+      "type": "number"
+    },
+    "min_markup": {
+      "type": "number"
+    },
+    "guards": {
+      "type": "object",
+      "required": ["max_price_step", "max_expectation_bias", "price_floor"],
+      "additionalProperties": false,
+      "properties": {
+        "max_price_step": {
+          "type": "number",
+          "minimum": 0
+        },
+        "max_expectation_bias": {
+          "type": "number"
+        },
+        "price_floor": {
+          "type": "number"
+        }
+      }
+    }
+  }
+}

--- a/tools/decider/schemas/wage_request.schema.json
+++ b/tools/decider/schemas/wage_request.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Wage decision request",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "run_id",
+    "tick",
+    "context",
+    "agent_id",
+    "country_id",
+    "current_wage",
+    "wage_floor",
+    "wage_ceiling",
+    "guards"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["1.0"]
+    },
+    "run_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "tick": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "context": {
+      "type": "string",
+      "enum": ["worker_reservation", "firm_offer"]
+    },
+    "agent_id": {
+      "type": "string"
+    },
+    "country_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "current_wage": {
+      "type": "number"
+    },
+    "wage_floor": {
+      "type": "number"
+    },
+    "wage_ceiling": {
+      "type": ["number", "null"]
+    },
+    "guards": {
+      "type": "object",
+      "required": ["max_wage_step"],
+      "additionalProperties": false,
+      "properties": {
+        "max_wage_step": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "employment_history": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      }
+    },
+    "recent_unemployment_rate": {
+      "type": "number"
+    },
+    "vacancies": {
+      "type": "number"
+    },
+    "recent_fill_rate": {
+      "type": "number"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {"context": {"const": "worker_reservation"}}
+      },
+      "then": {
+        "required": ["employment_history", "recent_unemployment_rate"],
+        "properties": {
+          "agent_id": {
+            "type": "string",
+            "pattern": "^C\\d+n\\d+$"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {"context": {"const": "firm_offer"}}
+      },
+      "then": {
+        "required": ["vacancies", "recent_fill_rate"],
+        "properties": {
+          "agent_id": {
+            "type": "string",
+            "pattern": "^F\\d+n\\d+$"
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What
- add JSON Schemas for firm, bank, and wage requests and validate payloads before stub responses
- surface readable 400 errors when validation fails
- document schema locations and validation workflow in docs/methods/decider.md

## Why
- aligns the stub with the Py2 client so malformed requests fail fast and provides a single source for future manuscript appendix schemas

## Testing
- python3 tools/decider/server.py --stub --check
- curl -s -X POST -H "Content-Type: application/json" -d '{}' http://127.0.0.1:8130/decide/firm
- curl -s -X POST -H "Content-Type: application/json" -d '{"schema_version":"1.0","run_id":0,"tick":0,"bank_id":"B0n0","country_id":0,"capital":10,"loan_supply":10,"reserves":0,"loan_book_value":0,"deposits":0,"non_allocated_money":0,"borrower":{},"guards":{}}' http://127.0.0.1:8130/decide/bank
- curl -s -X POST -H "Content-Type: application/json" -d '{"schema_version":"1.0","run_id":0,"tick":0,"context":"worker_reservation","agent_id":"C0n0","country_id":0,"current_wage":1.0,"wage_floor":0.0,"wage_ceiling":null,"guards":{"max_wage_step":0.04}}' http://127.0.0.1:8130/decide/wage
- quarto render docs

Closes #8