### PR TITLE
M1-03 — Deterministic cache and logging

### DIFF
--- a/docs/methods/decider.md
+++ b/docs/methods/decider.md
@@ -64,6 +64,21 @@ _Response (line-wrapped for readability):_
 {"direction": "hold", "price_step": 0.0, "expectation_bias": 0.0, "explanation": "stub: hold price; baseline heuristic"}
 ```
 
+## Deterministic cache
+
+- Module: `tools/decider/cache.py`
+- Key = SHA‐256 of `{endpoint, payload, temperature=0.0}` (the server refuses any other temperature so cached decisions stay deterministic).
+- Responses are deep-copied on the way in/out so callers cannot mutate the stored values.
+- Log lines show hits and misses, for example:
+
+  ```text
+  INFO cache hit /decide/firm key=4f6c5a2b
+  ```
+
+  The `key` prefix (first 8 hex chars) is enough to correlate with logs when debugging.
+
+On every request the server checks the cache before generating a response. The first call produces a `cache miss …` debug entry; subsequent identical requests (same endpoint + payload) reuse the cached payload and skip the downstream call. Clearing the cache is as simple as restarting the stub (later milestones will expose an explicit CLI flag when live mode ships).
+
 ## Roadmap
 
 Upcoming M1 issues extend this stub:

--- a/tools/decider/cache.py
+++ b/tools/decider/cache.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""Deterministic decision cache for the Decider service."""
+
+from __future__ import absolute_import
+
+import hashlib
+import json
+import threading
+from typing import Any, Dict, Optional, Tuple
+
+
+def _normalise_payload(payload):
+    """Return a JSON string with stable ordering for hashing."""
+
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+class DecisionCache(object):
+    """Thread-safe cache keyed by endpoint + payload hash."""
+
+    def __init__(self):
+        self._entries: Dict[str, Dict[str, Any]] = {}
+        self._lock = threading.Lock()
+
+    @staticmethod
+    def _key_material(endpoint: str, payload: Dict[str, Any], temperature: float) -> str:
+        if temperature != 0.0:
+            raise ValueError("temperature must be 0.0 for deterministic cache")
+        base = {
+            "endpoint": endpoint,
+            "payload": payload,
+            "temperature": 0.0,
+        }
+        return _normalise_payload(base)
+
+    def make_key(self, endpoint: str, payload: Dict[str, Any], temperature: float = 0.0) -> str:
+        raw = self._key_material(endpoint, payload, temperature)
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+    def get(
+        self,
+        endpoint: str,
+        payload: Dict[str, Any],
+        temperature: float = 0.0,
+    ) -> Tuple[str, Optional[Dict[str, Any]]]:
+        key = self.make_key(endpoint, payload, temperature)
+        with self._lock:
+            value = self._entries.get(key)
+        if value is None:
+            return key, None
+        return key, json.loads(json.dumps(value))
+
+    def set(self, key: str, response: Dict[str, Any]) -> None:
+        with self._lock:
+            self._entries[key] = json.loads(json.dumps(response))
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+
+__all__ = ["DecisionCache"]


### PR DESCRIPTION
## What
- add DecisionCache helper keyed by endpoint/payload/temperature and enforce temperature=0
- plug cache into the stub so repeated requests hit the cache, with log lines for hits/misses
- document cache behaviour (module path, log example, reset semantics) in docs/methods/decider.md

## Why
- ensures live/stub decisions stay deterministic and avoids re-doing identical LLM calls

## Testing
- python3 tools/decider/server.py --stub --check
- curl -s -X POST …firm payload (twice) @8130 to observe miss then hit
- curl -s -X POST …bank and …wage payloads @8130 to confirm caching works per endpoint
- quarto render docs

Closes #9