### PR TITLE
M2-01 — Code annotations with equation references

### DIFF
--- a/code/bank.py
+++ b/code/bank.py
@@ -64,12 +64,14 @@ class Bank:
              self.moneyCreated=self.loanAllocated-self.A-self.depositReceived
 
       def computeInterestRate(self,leverage):
+          # Eq. 27 (Caiani et al. 2016): spread-setting baseline before LLM.
           interestRate=self.xi*leverage+self.rDiscount 
           if interestRate<-0.001:
              print 'stop', stop 
           return interestRate
 
       def computeProbProvidingLoan(self,leverage,relPhi):
+          # Eq. 26 (Caiani et al. 2016): loan approval probability before LLM override.
           probLoan=math.exp(-1*self.iota*leverage)
           if relPhi<=1.0:
              probLoan=math.exp(-1*self.iotaRelPhi*leverage)

--- a/code/consumer.py
+++ b/code/consumer.py
@@ -273,6 +273,7 @@ class Consumer:
 
 
       def laborSupply(self,McountryUnemployement,McountryPastUnemployement,McountryYL,McountryPastYL):
+          # Eq. 1 (Caiani et al. 2016): reservation wage update before any LLM hook.
           #if self.laborSupplyAlreadyRevised=='no':
              u=McountryUnemployement[self.country]
              self.wageDirection=0 

--- a/code/firm.py
+++ b/code/firm.py
@@ -107,6 +107,7 @@ class Firm:
           
           
       def learning(self):       
+          # Eq. 12-14 (Caiani et al. 2016): pricing/expec update pre-LLM.
           if self.closing=='no':
              self.mind.alphaParameterSmooth16(self.phi,self.w,self.inventory,self.pastInventory,\
                                                self.price,self.productionEffective,self.xSold) 
@@ -347,6 +348,7 @@ class Firm:
               
 
       def wageOffered(self,McountryUnemployement,McountryPastUnemployement,McountryYL,McountryPastYL,t,McountryConsumer):
+          # Eq. 15 (Caiani et al. 2016): firm offered wage baseline rule.
           nWorkerDesired=self.nWorkerDesiredEffective
           l=self.l 
           p=self.price

--- a/docs/methods/eq_map.md
+++ b/docs/methods/eq_map.md
@@ -1,0 +1,18 @@
+---
+title: "Equation Map - LLM Hook Anchors"
+format:
+  html:
+    toc: false
+---
+
+This quick-reference page ties the Caiani equation numbers to the exact Python call sites we modify with LLM hooks. Each anchor points at a code comment that begins with `Eq.` so you can jump straight to the baseline heuristic before layering in LLM behavior.
+
+| Equation | Behavioral rule | Code anchor | Notes |
+| --- | --- | --- | --- |
+| Eq. 1 | Worker reservation wage | `code/consumer.py` -> `Consumer.laborSupply` (`# Eq. 1 ...`) | Reservation wage clamp + direction choice prior to any LLM override. |
+| Eq. 12-14 | Firm pricing & expectations | `code/firm.py` -> `Firm.learning` (`# Eq. 12-14 ...`) | Calls `Mind.alphaParameterSmooth16` to update price/expected demand. |
+| Eq. 15 | Firm offered wage | `code/firm.py` -> `Firm.wageOffered` (`# Eq. 15 ...`) | Baseline wage offer before bargaining and upcoming LLM guardrails. |
+| Eq. 26 | Loan approval probability | `code/bank.py` -> `Bank.computeProbProvidingLoan` (`# Eq. 26 ...`) | Maps leverage/phi signal to approval odds; upstream of `matchingCredit.matchCreditOpen`. |
+| Eq. 27 | Loan spread setting | `code/bank.py` -> `Bank.computeInterestRate` (`# Eq. 27 ...`) | Linear leverage-to-spread rule feeding the credit match. |
+
+For more context on how the manuscript cites these anchors, see `docs/appendix_eq_map.qmd` once the appendix draft lands.

--- a/tools/decider/schemas/bank_request.schema.json
+++ b/tools/decider/schemas/bank_request.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Bank credit decision request",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "run_id",
+    "tick",
+    "bank_id",
+    "country_id",
+    "capital",
+    "loan_supply",
+    "reserves",
+    "loan_book_value",
+    "deposits",
+    "non_allocated_money",
+    "borrower",
+    "guards"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["1.0"]
+    },
+    "run_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "tick": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "bank_id": {
+      "type": "string",
+      "pattern": "^B\\d+n\\d+$"
+    },
+    "country_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "capital": {
+      "type": "number"
+    },
+    "loan_supply": {
+      "type": "number"
+    },
+    "reserves": {
+      "type": "number"
+    },
+    "loan_book_value": {
+      "type": "number"
+    },
+    "deposits": {
+      "type": "number"
+    },
+    "non_allocated_money": {
+      "type": "number"
+    },
+    "borrower": {
+      "type": "object",
+      "required": [
+        "firm_id",
+        "country_id",
+        "loan_request",
+        "leverage",
+        "relative_productivity",
+        "profit_rate"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "firm_id": {
+          "type": "string",
+          "pattern": "^F\\d+n\\d+$"
+        },
+        "country_id": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "loan_request": {
+          "type": "number"
+        },
+        "leverage": {
+          "type": "number"
+        },
+        "relative_productivity": {
+          "type": "number"
+        },
+        "profit_rate": {
+          "type": "number"
+        }
+      }
+    },
+    "guards": {
+      "type": "object",
+      "required": ["spread_min_bps", "spread_max_bps"],
+      "additionalProperties": false,
+      "properties": {
+        "spread_min_bps": {
+          "type": "number"
+        },
+        "spread_max_bps": {
+          "type": "number"
+        }
+      }
+    }
+  }
+}

--- a/tools/decider/schemas/firm_request.schema.json
+++ b/tools/decider/schemas/firm_request.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Firm pricing & expectations request",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "run_id",
+    "tick",
+    "country_id",
+    "firm_id",
+    "price",
+    "unit_cost",
+    "inventory",
+    "inventory_value",
+    "production_effective",
+    "production_capacity",
+    "sales_last_period",
+    "loan_demand",
+    "loan_received",
+    "net_worth",
+    "expected_wage",
+    "markup",
+    "min_markup",
+    "guards"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["1.0"]
+    },
+    "run_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "tick": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "country_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "firm_id": {
+      "type": "string",
+      "pattern": "^F\\d+n\\d+$"
+    },
+    "tradable": {
+      "type": ["boolean", "null"]
+    },
+    "price": {
+      "type": "number"
+    },
+    "unit_cost": {
+      "type": "number"
+    },
+    "inventory": {
+      "type": "number"
+    },
+    "inventory_value": {
+      "type": "number"
+    },
+    "production_effective": {
+      "type": "number"
+    },
+    "production_capacity": {
+      "type": "number"
+    },
+    "sales_last_period": {
+      "type": "number"
+    },
+    "loan_demand": {
+      "type": "number"
+    },
+    "loan_received": {
+      "type": "number"
+    },
+    "net_worth": {
+      "type": "number"
+    },
+    "expected_wage": {
+      "type": "number"
+    },
+    "markup": {
+      "type": "number"
+    },
+    "min_markup": {
+      "type": "number"
+    },
+    "guards": {
+      "type": "object",
+      "required": ["max_price_step", "max_expectation_bias", "price_floor"],
+      "additionalProperties": false,
+      "properties": {
+        "max_price_step": {
+          "type": "number",
+          "minimum": 0
+        },
+        "max_expectation_bias": {
+          "type": "number"
+        },
+        "price_floor": {
+          "type": "number"
+        }
+      }
+    }
+  }
+}

--- a/tools/decider/schemas/wage_request.schema.json
+++ b/tools/decider/schemas/wage_request.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Wage decision request",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "run_id",
+    "tick",
+    "context",
+    "agent_id",
+    "country_id",
+    "current_wage",
+    "wage_floor",
+    "wage_ceiling",
+    "guards"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["1.0"]
+    },
+    "run_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "tick": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "context": {
+      "type": "string",
+      "enum": ["worker_reservation", "firm_offer"]
+    },
+    "agent_id": {
+      "type": "string"
+    },
+    "country_id": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "current_wage": {
+      "type": "number"
+    },
+    "wage_floor": {
+      "type": "number"
+    },
+    "wage_ceiling": {
+      "type": ["number", "null"]
+    },
+    "guards": {
+      "type": "object",
+      "required": ["max_wage_step"],
+      "additionalProperties": false,
+      "properties": {
+        "max_wage_step": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "employment_history": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      }
+    },
+    "recent_unemployment_rate": {
+      "type": "number"
+    },
+    "vacancies": {
+      "type": "number"
+    },
+    "recent_fill_rate": {
+      "type": "number"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {"context": {"const": "worker_reservation"}}
+      },
+      "then": {
+        "required": ["employment_history", "recent_unemployment_rate"],
+        "properties": {
+          "agent_id": {
+            "type": "string",
+            "pattern": "^C\\d+n\\d+$"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {"context": {"const": "firm_offer"}}
+      },
+      "then": {
+        "required": ["vacancies", "recent_fill_rate"],
+        "properties": {
+          "agent_id": {
+            "type": "string",
+            "pattern": "^F\\d+n\\d+$"
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What
- add inline `Eq.<n>` comments at the firm, bank, and consumer decision hooks so future LLM logic lands at the right anchors
- introduce a lightweight equation-map page that collects those anchors for manuscript cross-reference

## Why
- ensures the Caiani numbering is visible directly in code where the live hooks will attach
- provides the methods team a stable link target while appendix content is in flight

## Artifacts
- docs/methods/eq_map.md

## Affected pages
- docs/methods/eq_map.md

## Evidence
- \

Closes #16