### PR TITLE
M3-01 — Insert firm pricing LLM hook (live) with fallback

### DIFF
--- a/code/llm_runtime.py
+++ b/code/llm_runtime.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""Shared LLM runtime context for the Python 2 simulation."""
+
+from __future__ import absolute_import
+
+try:
+    from llm_bridge_client import LLMBridgeClient
+except ImportError:  # pragma: no cover - package import fallback
+    from .llm_bridge_client import LLMBridgeClient
+
+_CONTEXT = {
+    'parameter': None,
+    'client': None,
+}
+
+
+def configure(parameter):
+    """Register the active ``Parameter`` instance for downstream hooks."""
+
+    _CONTEXT['parameter'] = parameter
+    _CONTEXT['client'] = None
+
+
+def get_parameter():
+    return _CONTEXT.get('parameter')
+
+
+def get_client():
+    parameter = get_parameter()
+    if not parameter:
+        return None
+    client = _CONTEXT.get('client')
+    if client is None:
+        timeout = parameter.llm_timeout_ms or 0
+        timeout = float(timeout) / 1000.0
+        client = LLMBridgeClient(parameter.llm_server_url, timeout=timeout)
+        _CONTEXT['client'] = client
+    return client
+
+
+def firm_enabled():
+    parameter = get_parameter()
+    return bool(parameter and parameter.use_llm_firm_pricing)
+
+
+def log_fallback(block, reason, detail=None):
+    message = '[LLM %s] fallback: %s' % (block, reason)
+    if detail:
+        message = message + ' (%s)' % detail
+    print message
+
+
+__all__ = ['configure', 'get_client', 'get_parameter', 'firm_enabled', 'log_fallback']

--- a/code/timing.py
+++ b/code/timing.py
@@ -16,6 +16,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+# flake8: noqa
 from parameter import *
 from initialize import *
 from firm import *
@@ -36,6 +37,7 @@ from globalInnovation import *
 from printParameters import *
 from centralBankUnion import *
 from policy import *
+from llm_runtime import configure as configure_llm
 
 
 _LOG_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'timing.log'))
@@ -77,6 +79,7 @@ def run_simulation(parameter=None, progress=True):
     para.directory()
     log_llm_toggles(para)
     printPa=PrintParameters(para.name,para.folder)
+    configure_llm(para)
 
     for run in para.Lrun:
         if para.weSeedRun=='yes':
@@ -125,14 +128,16 @@ def run_simulation(parameter=None, progress=True):
             print 'name ', para.name, '---- run', run, ' --- t ',  t
 
             maLaborCapital.bargaining(ite.McountryFirm,ite.McountryConsumer,\
-                                     aggrega.McountryUnemployement,aggrega.McountryPastUnemployement,aggrega.McountryYL,aggrega.McountryPastYL,t)
+                                 aggrega.McountryUnemployement,aggrega.McountryPastUnemployement,aggrega.McountryYL,aggrega.McountryPastYL,t)
 
             for country in ite.McountryFirm:
-                for firm in ite.McountryFirm[country]: 
-                    ite.McountryFirm[country][firm].learning()  
-                    #ite.McountryFirm[country][firm].wageOffered(aggrega.McountryAvPrice,\
+                for firm_key in ite.McountryFirm[country]: 
+                    firm_obj = ite.McountryFirm[country][firm_key]
+                    firm_obj.llm_tick = t
+                    firm_obj.learning()  
+                    #firm_obj.wageOffered(aggrega.McountryAvPrice,\
                     #                   aggrega.McountryUnemployement,para.nconsumer,aggrega.DcountryAvWage)          
-                    ite.McountryFirm[country][firm].productionDesired(ite.McountryBank,ite.McountryCentralBank,t,aggrega.McountryAvPrice)
+                    firm_obj.productionDesired(ite.McountryBank,ite.McountryCentralBank,t,aggrega.McountryAvPrice)
 
             maCredit.creditNetworkEvolution(ite.McountryFirm,ite.McountryBank,ite.McountryCentralBank,\
                                             gloInnovation.DglobalPhiNotTradable,gloInnovation.DglobalPhiTradable,aggrega.avPhiGlobalTradable)
@@ -145,8 +150,9 @@ def run_simulation(parameter=None, progress=True):
                                    ite.McountryBank,ite.McountryCentralBank,aggrega.McountryUnemployement)
 
             for country in ite.McountryFirm:
-                for firm in ite.McountryFirm[country]: 
-                    ite.McountryFirm[country][firm].effectiveSelling(gloInnovation.DglobalPhiNotTradable,aggrega.avPhiGlobalTradable,\
+                for firm_key in ite.McountryFirm[country]: 
+                    firm_obj = ite.McountryFirm[country][firm_key]
+                    firm_obj.effectiveSelling(gloInnovation.DglobalPhiNotTradable,aggrega.avPhiGlobalTradable,\
                                                aggrega.avPriceGlobalTradable,aggrega.McountryAvPriceNotTradable,gloInnovation.DglobalPhi,aggrega.McountryAvPrice)
 
             for country in ite.McountryConsumer:


### PR DESCRIPTION
## What
- add a lightweight LLM runtime context so the Py2 simulation can reuse a configured 
- wrap the firm pricing update in  with payload construction, validation, and guarded application of LLM decisions
- annotate the main loop so each firm knows the current tick before calling the Decider

## Why
- enables the live firm pricing path required for the OFF/ON comparisons while keeping fallbacks deterministic

## Evidence
- \
- 

Closes #24],