### PR TITLE
M1-02 — Decision schemas (firm, bank, wage) + validation errors

### DIFF
--- a/docs/methods/decider.md
+++ b/docs/methods/decider.md
@@ -68,26 +68,23 @@ curl -s -X POST \
         "tick": 0,
         "country_id": 0,
         "firm_id": "F0n0",
-        "price": 1.0,
+        "price": 1.05,
         "unit_cost": 1.0,
-        "inventory": 0,
-        "inventory_value": 0,
-        "production_effective": 0,
-        "production_capacity": 10.0,
-        "sales_last_period": 0,
-        "loan_demand": 0,
-        "loan_received": 0,
-        "net_worth": 10,
-        "expected_wage": 1.0,
-        "markup": 0.0,
-        "min_markup": 0.0,
+        "inventory": 2.5,
+        "inventory_value": 2.5,
+        "production_effective": 3.0,
+        "baseline": {
+          "price": 1.05,
+          "expected_demand": 3.2,
+          "producing": 2.8
+        },
         "guards": {
           "max_price_step": 0.04,
           "max_expectation_bias": 0.04,
           "price_floor": 1.0
         }
       }' \
-  http://127.0.0.1:8000/decide/firm
+  http://127.0.0.1:8000/decide/firm | jq
 ```
 
 ### Friendly validation errors
@@ -103,8 +100,8 @@ curl -s -X POST -H "Content-Type: application/json" -d '{}' \
 {
   "error": "invalid_request",
   "detail": [
-    { "path": [], "message": "'schema_version' is a required property" },
-    { "path": [], "message": "'run_id' is a required property" }
+    { "path": ["baseline"], "message": "'baseline' is a required property" },
+    { "path": ["guards"], "message": "'guards' is a required property" }
   ]
 }
 ```

--- a/tools/decider/schemas/bank_request.schema.json
+++ b/tools/decider/schemas/bank_request.schema.json
@@ -8,16 +8,9 @@
     "tick",
     "bank_id",
     "country_id",
-    "capital",
-    "loan_supply",
-    "reserves",
-    "loan_book_value",
-    "deposits",
-    "non_allocated_money",
     "borrower",
     "guards"
   ],
-  "additionalProperties": false,
   "properties": {
     "schema_version": {
       "type": "string",
@@ -62,12 +55,9 @@
       "required": [
         "firm_id",
         "country_id",
-        "loan_request",
-        "leverage",
-        "relative_productivity",
-        "profit_rate"
+        "loan_request"
       ],
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "firm_id": {
           "type": "string",
@@ -94,7 +84,7 @@
     "guards": {
       "type": "object",
       "required": ["spread_min_bps", "spread_max_bps"],
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "spread_min_bps": {
           "type": "number"

--- a/tools/decider/schemas/firm_request.schema.json
+++ b/tools/decider/schemas/firm_request.schema.json
@@ -13,14 +13,7 @@
     "inventory",
     "inventory_value",
     "production_effective",
-    "production_capacity",
-    "sales_last_period",
-    "loan_demand",
-    "loan_received",
-    "net_worth",
-    "expected_wage",
-    "markup",
-    "min_markup",
+    "baseline",
     "guards"
   ],
   "additionalProperties": false,
@@ -86,6 +79,22 @@
     },
     "min_markup": {
       "type": "number"
+    },
+    "baseline": {
+      "type": "object",
+      "required": ["price", "expected_demand"],
+      "additionalProperties": false,
+      "properties": {
+        "price": {
+          "type": ["number", "null"]
+        },
+        "expected_demand": {
+          "type": "number"
+        },
+        "producing": {
+          "type": "number"
+        }
+      }
     },
     "guards": {
       "type": "object",


### PR DESCRIPTION
## What
- reshape the firm request schema to match the live Py2 payload (baseline + guards) and loosen optional metrics for future fields
- relax the bank schema to accept the minimal borrower packet while still enforcing guard bounds, retaining optional extras
- refresh the docs example to show the new payload and highlight the schema validation error message users should expect

## Why
- the previous schemas rejected the actual payload emitted by the new firm hook; downstream hooks need lenient-but-bounded schemas

## Evidence
- `python3 tools/decider/server.py --stub --check`
- `python3 - <<'PY' ...` jsonschema validation for firm/bank/wage payloads

Closes #8
