### PR TITLE
32 — Insert bank approval/spread LLM hook (live) with fallback

### DIFF
--- a/code/llm_runtime.py
+++ b/code/llm_runtime.py
@@ -43,6 +43,11 @@ def firm_enabled():
     return bool(parameter and parameter.use_llm_firm_pricing)
 
 
+def bank_enabled():
+    parameter = get_parameter()
+    return bool(parameter and parameter.use_llm_bank_credit)
+
+
 def log_fallback(block, reason, detail=None):
     message = '[LLM %s] fallback: %s' % (block, reason)
     if detail:
@@ -50,4 +55,4 @@ def log_fallback(block, reason, detail=None):
     print message
 
 
-__all__ = ['configure', 'get_client', 'get_parameter', 'firm_enabled', 'log_fallback']
+__all__ = ['configure', 'get_client', 'get_parameter', 'firm_enabled', 'bank_enabled', 'log_fallback']

--- a/code/matchingCredit.py
+++ b/code/matchingCredit.py
@@ -85,11 +85,17 @@ class MatchingCredit:
                                  leverage=self.MloanDemand[i][5] 
                                  relPhi=self.MloanDemand[i][6]
                                  countryBank=self.MloanSupply[j][2] 
-                                 probLoan=McountryBank[countryBank][ideBank].computeProbProvidingLoan(leverage,relPhi)
-                                 loanOffered=min(maxLoanFirm,supply) 
+                                 bank_obj=McountryBank[countryBank][ideBank]
+                                 firm_obj=McountryFirm[countryFirm][ideFirm]
+                                 loan_request=demand
+                                 decision=bank_obj.credit_decision(firm_obj,leverage,relPhi,loan_request,supply,maxLoanFirm)
+                                 probLoan=decision.get('probability',0.0)
+                                 loanOffered=decision.get('credit_limit',0.0)
+                                 if not decision.get('approve',True):
+                                    loanOffered=0.0
                                  a=random.uniform(0,1)
                                  if a>probLoan:
-                                    loanOffered=0                                 
+                                    loanOffered=0.0
                                  if demand>=loanOffered:
                                     loan=loanOffered
                                  if demand<loanOffered:
@@ -101,7 +107,7 @@ class MatchingCredit:
                                     self.MloanSupply[j][4]=self.MloanSupply[j][4]+loan                                    
                                     if  ideBank!=McountryBank[countryBank][ideBank].ide:
                                         print 'stop', stop   
-                                    interestRate=McountryBank[countryBank][ideBank].computeInterestRate(leverage)
+                                    interestRate=decision.get('interest_rate',bank_obj.computeInterestRate(leverage))
                                     interestRateDeposit=McountryBank[countryBank][ideBank].rDeposit 
                                     McountryFirm[countryFirm][ideFirm].receavingLoan(ideBank,loan,interestRate,\
                                                                      interestRateDeposit,countryBank,McountryBank,McountryCentralBank)
@@ -132,4 +138,3 @@ class MatchingCredit:
                               
                              
        
-

--- a/code/timing.py
+++ b/code/timing.py
@@ -140,6 +140,11 @@ def run_simulation(parameter=None, progress=True):
                     #                   aggrega.McountryUnemployement,para.nconsumer,aggrega.DcountryAvWage)          
                     firm_obj.productionDesired(ite.McountryBank,ite.McountryCentralBank,t,aggrega.McountryAvPrice)
 
+            for country in ite.McountryBank:
+                for bank_key in ite.McountryBank[country]:
+                    bank_obj = ite.McountryBank[country][bank_key]
+                    bank_obj.llm_tick = t
+
             maCredit.creditNetworkEvolution(ite.McountryFirm,ite.McountryBank,ite.McountryCentralBank,\
                                             gloInnovation.DglobalPhiNotTradable,gloInnovation.DglobalPhiTradable,aggrega.avPhiGlobalTradable)
 


### PR DESCRIPTION
## What
- call the Decider from bank credit decisions via the shared runtime toggle/client
- clamp approvals/limits/spreads and track fallbacks when the LLM is unavailable or invalid
- integrate decisions into the matching loop and propagate tick metadata for accurate payloads

## Why
- fulfill M4-01 by wiring the bank block to the Decider while preserving baseline parity and guards

## Testing
- python2 -m compileall code
- python2 - <<'PY' … (OFF) with use_llm_bank_credit=False, ncycle=2, run=0, stub=http://127.0.0.1:8204
- python2 - <<'PY' … (ON) with use_llm_bank_credit=True, ncycle=2, run=0, stub=http://127.0.0.1:8204

Closes #32