### PR TITLE
20 — Methods hub and supporting pages

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -19,12 +19,22 @@ website:
         href: conventions.md
       - text: "Repro Manual"
         href: repro_manual.qmd
-      - text: "Decider Stub"
-        href: methods/decider.md
-      - text: "Py2 Client"
-        href: methods/py2_client.md
-      - text: "Fallback Semantics"
-        href: methods/fallbacks.qmd
+      - text: "Methods"
+        menu:
+          - text: "Methods Hub"
+            href: methods/index.qmd
+          - text: "Model Overview"
+            href: methods/model_overview.md
+          - text: "Variable Dictionary"
+            href: methods/variables.md
+          - text: "Decider Stub"
+            href: methods/decider.md
+          - text: "Py2 Client"
+            href: methods/py2_client.md
+          - text: "Fallback Semantics"
+            href: methods/fallbacks.qmd
+          - text: "A/B Runner Helper"
+            href: methods/runners.md
 
 format:
   html:

--- a/docs/methods/index.qmd
+++ b/docs/methods/index.qmd
@@ -1,0 +1,35 @@
+---
+title: "Methods Hub"
+description: "Landing page for the Caiani AB-SFC live LLM instrumentation, linking to method-focused documentation and reference artifacts."
+format:
+  html:
+    toc: true
+    toc-depth: 2
+---
+
+# Methods Hub {#methods-index}
+
+This hub gathers the technical documentation that underpins the live LLM instrumentation of the Caiani AB-SFC model. Use it as the starting point for detailed discussions of the architecture, runtime safeguards, data exports, and manuscript-ready metrics.
+
+## Model Context
+
+- [Model Overview](model_overview.md) — Non-technical summary of agents, markets, timing, and where LLM hooks integrate with the legacy Python 2 loop (@ref(methods-model-overview)).
+- [Equation Map (coming soon)](eq_map.md) — Crosswalk between manuscript equations and code touchpoints (see Issue #74 for upcoming appendix content).
+
+## Runtime Architecture
+
+- [Decider Stub](decider.md) — Python 3 microservice that serves deterministic decisions, schema validation, and timeout controls.
+- [Py2 Client](py2_client.md) — HTTP bridge from the legacy simulation to the Decider, including error taxonomy and fallback triggers.
+- [Fallback Semantics](fallbacks.qmd) — Detailed explanation of guardrails, clamping rules, and logging for LLM fallbacks.
+- [A/B Runner Helper](runners.md) — Convenience wrapper for producing short OFF/ON runs and pointers to the stub data bundle.
+
+## Data & Metrics
+
+- [Variable Dictionary](variables.md) — Metric-by-metric definitions, CSV column references, and aggregation formulas for manuscript tables (@ref(methods-variables)).
+- `data/core_metrics.csv` — Canonical 240-tick baseline/LLM comparison exported by `code/timing.py`.
+- `docs/stubs/` — 20-tick preview dataset (LLM OFF) for quick Quarto prototypes and smoke checks.
+
+## Next Steps
+
+- Coordinate with Issue #23 (M2 sign-off) once the hub and supporting pages render cleanly via `quarto render docs`.
+- Update this index as additional Methods pages (e.g., caching design, wage hook instrumentation) land in later milestones.

--- a/docs/methods/model_overview.md
+++ b/docs/methods/model_overview.md
@@ -1,0 +1,81 @@
+---
+title: "Model Overview"
+description: "A non-technical summary of the Caiani AB-SFC model structure, agents, markets, and the integration of live LLM decisions as instrumented in this repository."
+format:
+  html:
+    toc: true
+    toc-depth: 3
+---
+
+# Model Overview {#methods-model-overview}
+
+This page provides a high-level overview of the Agent-Based Stock-Flow Consistent (AB-SFC) macroeconomic model used in this project, originally developed by Caiani et al. (2017), and adapted here to incorporate live Large Language Model (LLM) behavioral hooks.
+
+::: {.callout-important}
+## Scope Disclaimer
+This repository treats the existing Python 2 codebase as a sandbox for a **methods contribution**. The parameters and simulation outcomes differ from the original Caiani calibration; we do not attempt to replicate the original paper’s results. The focus is on demonstrating a pattern for safely integrating live LLM decisions.
+:::
+
+## The Baseline AB-SFC Framework {#sec-overview-baseline}
+
+The model simulates a monetary union composed of multiple countries (five in the default configuration). It is characterized by decentralized interactions among heterogeneous agents, imperfect information, and adaptive behavior.
+
+### Agents and Markets {#sec-overview-agents}
+
+The simulation includes several classes of agents:
+
+- **Households/Workers:** Supply labor, consume goods, and hold equity. They set reservation wages and search for employment.
+- **Firms:** Produce goods (tradable or non-tradable), hire workers, set prices, form expectations, and invest in R&D to improve productivity.
+- **Banks:** Accept deposits and provide credit to firms. They evaluate loan applications, set credit limits, and determine interest rate spreads based on borrower leverage.
+- **Government Sector:** Collects taxes and provides public spending (lump-sum transfers) within each country, adhering to deficit-to-GDP ratio targets.
+- **Central Banks:** A Union Central Bank sets the policy rate (using a Taylor rule), while National Central Banks provide liquidity to commercial banks and absorb residual government bonds.
+
+These agents interact across several markets:
+
+- **Consumption Goods Market:** Uses a Hotelling matching protocol, where consumers balance price and product variety when choosing suppliers.
+- **Labor Market:** Decentralized matching where firms offer wages and workers accept based on their reservation wages. Bargaining power is influenced by the aggregate unemployment rate.
+- **Credit Market:** Firms seek loans to finance production and R&D. Banks may ration credit based on balance sheet constraints and applicant risk.
+- **Bond and Deposit Markets:** Manage savings and government financing.
+
+### Accounting and Consistency
+
+A core feature of the model is its adherence to **Stock-Flow Consistency (SFC)**. Every financial flow comes from somewhere and goes somewhere, and all stocks (assets and liabilities) are rigorously tracked via ledgers (`lebalance.py`). This ensures that the macroeconomic accounting is sound and prevents "black holes" where money disappears or appears arbitrarily.
+
+## Simulation Loop and Timing {#sec-overview-timing}
+
+The simulation proceeds in discrete time steps (ticks). The order of operations within each tick is crucial for causality and consistency:
+
+1. **Bargaining and Expectations:** Labor market bargaining begins (`maLaborCapital.bargaining()`). Firms update their expectations, set prices (`firm.learning()`), and determine desired production levels (`firm.productionDesired()`).
+2. **Credit Market:** Firms request loans, and banks evaluate applications and set terms (`maCredit.creditNetworkEvolution()`).
+3. **Production and Sales:** Firms hire workers (`maLaborCapital.working()`) and produce goods, followed by interactions on the consumption market (`firm.effectiveSelling()`).
+4. **Income and Policy:** Households receive income (`consumer.income()`); governments calculate taxes, set spending, and issue bonds (`etat.expectingTaxation()`, `poli.implementingPolicy()`).
+5. **Innovation and Dynamics:** R&D outcomes and technological spillovers occur (`gloInnovation.spillover()`). Firms and banks may exit if insolvent, and new agents may enter (`firm.existence()`).
+6. **Aggregation and Monetary Policy:** Macroeconomic aggregates are computed, consistency checks are performed (e.g., `aggrega.checkNetWorth()`), and the Union Central Bank updates the policy rate (`centralBankUnion.taylorRule1()`).
+
+## Live LLM Integration {#sec-overview-llm}
+
+This project modifies the baseline model by interposing live LLM decisions at specific behavioral functions within the simulation loop. The LLM acts as a microservice (the "Decider") that provides qualitative cues based on local agent states.
+
+### LLM Hooks
+
+The LLM influences decisions in three key areas during steps 1 and 2 of the simulation loop:
+
+1. **Firm Pricing and Expectations (Eq. 12–14):** Determining the direction (up/down/hold) and step size for price adjustments and expectation biases.
+2. **Bank Credit Decisions (Eq. 26–27):** Influencing loan approval, setting credit limits, and determining the interest rate spread (in basis points).
+3. **Wage Setting (Eq. 1, 15):** Determining the direction and step size for worker reservation wages and firm offered wages.
+
+### Safety and Workflow
+
+The integration is designed with strict safety protocols to preserve the model's SFC properties and ensure stability. The Python 2 simulation communicates with the Python 3 Decider service via HTTP.
+
+- **Guards and Bounds:** All LLM-suggested values are strictly bounded in the Python 2 client *before* state updates. This includes caps on price/wage steps (default 0.04), expectation bias caps (0.04), enforcing a unit-cost price floor (`p ≥ w/φ`), spread clamps, and leverage monotonicity checks.
+- **Timeouts and Fallbacks:** Hard timeouts are enforced. If the LLM fails to respond, returns invalid JSON, or suggests values outside the acceptable bounds, the system immediately reverts to the baseline numeric heuristics.
+
+## Where to Look Next {#sec-overview-next}
+
+For more detailed information on the implementation, refer to the following Methods pages:
+
+- [**Decider Stub**](decider.md): Details on the LLM microservice design, API schema, and configuration.
+- [**Py2 Client**](py2_client.md): Description of the Python 2 HTTP client contract and error handling.
+- [**Fallback Semantics**](fallbacks.qmd): A deep dive into the fallback pipeline, guardrails, and logging mechanisms.
+- @ref(methods-variables): Precise definitions and computation details for all core metrics used in the manuscript.

--- a/docs/methods/variables.md
+++ b/docs/methods/variables.md
@@ -1,0 +1,127 @@
+---
+title: "Variable Dictionary"
+description: "A concise dictionary mapping manuscript metrics to their source CSV columns, detailing their computation, inputs, and context within the AB-SFC model."
+format:
+  html:
+    toc: true
+    toc-depth: 3
+---
+
+# Variable Dictionary {#methods-variables}
+
+This document defines the core metrics used to evaluate simulation outcomes in the manuscript. It details how each metric is computed within the simulation (`code/aggregator.py`) and identifies the corresponding columns in the output datasets.
+
+## Data Sources and Computation {#sec-variables-sources}
+
+The metrics described here are derived from the simulation output. The primary artifact for analysis is:
+
+- **Canonical Baseline Data:** `data/core_metrics.csv`. This file contains scalar metrics computed over the full 240-tick horizon for baseline (LLM OFF) and LLM-enhanced (LLM ON) scenarios.
+
+  ```csv
+  # Sample from data/core_metrics.csv
+  scenario,metric,value
+  llm_on,price_dispersion,0.16932996561384545
+  baseline,price_dispersion,0.16932996561384545
+  ...
+  ```
+
+Metrics are computed in two stages by the aggregator:
+
+1. **Tick-level Series Construction:** Intermediate variables are calculated at each time step based on the aggregate state of agents.
+2. **Aggregation into Scalars:** The time series are aggregated (e.g., averaged or standard deviation calculated) over the simulation horizon to produce the final scalar metrics. Standard statistical definitions (mean and standard deviation) are used, with appropriate guardrails implemented.
+
+::: {.callout-tip}
+## Using the Preview Bundle
+For quick previews and validation, a 20-tick baseline run (LLM hooks disabled) is available in the `docs/stubs/` directory. This bundle includes:
+
+- `docs/stubs/micro_run_core_metrics.csv`: Scalar metrics for the 20-tick run.
+- `docs/stubs/micro_run_metric_series.csv`: Tick-level time series data used to compute the scalars.
+
+These files can be used to trace the computations described below.
+:::
+
+## Metric Definitions {#sec-variables-definitions}
+
+The following sections detail the metrics organized by macroeconomic domain. In the source CSV files, metrics are identified by the `metric` column, and their final scalar value is in the `value` column.
+
+### Price Dynamics (Inflation and Dispersion) {#sec-variables-price}
+
+These metrics capture the stability and heterogeneity of prices across the monetary union, driven by firm pricing decisions (LLM-augmented via Eq. 12–14).
+
+| Metric | Source CSV Column | Computation | Notes/Agents |
+| :--- | :--- | :--- | :--- |
+| **`inflation_volatility`** | `value` where `metric == "inflation_volatility"` | Standard deviation across ticks of the country-average inflation rate. <br><br> 1. **Tick-level:** Compute average inflation across all countries: `avg_inflation = sum(McountryInflation) / len(Lcountry)`. <br> 2. **Scalar:** Compute the standard deviation of the `avg_inflation` time series (`std(series['inflation'])`). <br><br> **Guardrails:** Standard deviation calculation includes a zero guard on variance (`math.sqrt(max(variance, 0.0))`) to ensure a real result. | Inputs supplied by **Firms** (pricing decisions) aggregated at the country level. Captures the temporal stability of the overall price level. |
+| **`price_dispersion`** | `value` where `metric == "price_dispersion"` | Time-average of the sales-weighted price dispersion across all firms. <br><br> 1. **Tick-level:** Compute the sales-weighted variance of prices across firms; take the square root to obtain dispersion. <br> 2. **Scalar:** Compute the mean of the `price_dispersion` time series (`mean(series['price_dispersion'])`). <br><br> **Guardrails:** Variance calculation includes a zero guard (`math.sqrt(max(variance_price, 0.0))`) to handle floating-point noise. | Inputs supplied by **Firms** (prices and sales volumes). Measures the cross-sectional heterogeneity of prices, reflecting competition and market structure. |
+
+### Labor Market (Wages and Employment) {#sec-variables-labor}
+
+These metrics assess labor-market outcomes, focusing on wage heterogeneity and the efficiency of matching between workers and firms (LLM-augmented via Eq. 1 and 15).
+
+| Metric | Source CSV Column | Computation | Notes/Agents |
+| :--- | :--- | :--- | :--- |
+| **`wage_dispersion`** | `value` where `metric == "wage_dispersion"` | Time-average of the employment-weighted wage dispersion. <br><br> 1. **Tick-level:** Compute the employment-weighted variance of wages; take the square root. <br> 2. **Scalar:** Compute the mean of the `wage_dispersion` time series (`mean(series['wage_dispersion'])`). <br><br> **Guardrails:** Variance calculation includes a zero guard (`math.sqrt(max(variance_wage, 0.0))`). | Inputs supplied by **Firms** (offered wages) and **Workers** (reservation wages) during matching. Measures cross-sectional wage heterogeneity. |
+| **`fill_rate`** | `value` where `metric == "fill_rate"` | Time-average of the vacancy fill rate. <br><br> 1. **Tick-level:** Ratio of total employed labor to total desired labor: `fill_employed_total / float(fill_desired_total)`. Defaults to 1.0 if desired labor is zero. <br> 2. **Scalar:** Compute the mean of the `fill_rate` time series (`mean(series['fill_rate'])`). <br><br> **Guardrails:** Tick-level rate defaults to 1.0 when demand is zero; the scalar mean defaults to 1.0 if the series is empty. | Inputs supplied by **Firms** (desired labor demand) and the matching outcome from `maLaborCapital`. Indicates how effectively vacancies are filled. |
+
+### Credit and Finance {#sec-variables-credit}
+
+These metrics track the cost and intensity of credit within the economy, driven by bank lending decisions (LLM-augmented via Eq. 26–27).
+
+| Metric | Source CSV Column | Computation | Notes/Agents |
+| :--- | :--- | :--- | :--- |
+| **`avg_spread`** | `value` where `metric == "avg_spread"` | Time-average of the loan-volume-weighted interest rate spread. <br><br> 1. **Tick-level:** Weighted average spread charged by banks over the policy rate: `spread_weighted_sum / float(spread_loan_sum)`. Defaults to 0.0 if no loans are granted. <br> 2. **Scalar:** Compute the mean of the `avg_spread` time series (`mean(series['avg_spread'])`). | Inputs supplied by **Banks** (spread setting) and loan volumes during credit-market matching. Reflects perceived credit risk and borrowing costs. |
+| **`loan_output_ratio`** | `value` where `metric == "loan_output_ratio"` | Time-average of the ratio of total credit stock to total output. <br><br> 1. **Tick-level:** Ratio of total outstanding credit to aggregate output: `credit_total / float(total_output)`. Defaults to 0.0 if output is zero. <br> 2. **Scalar:** Compute the mean of the `loan_output_ratio` time series (`mean(series['loan_output_ratio'])`). | Inputs derived from **Banks** (credit totals) and **Firms** (aggregate output). Measures the economy’s financial leverage. |
+
+## Reference Implementation Snippet {#sec-variables-snippet}
+
+```python
+# code/aggregator.py (abbreviated for reference)
+self._metric_series = {
+    'inflation': [],
+    'price_dispersion': [],
+    'total_credit': [],
+    'avg_spread': [],
+    'wage_dispersion': [],
+    'fill_rate': [],
+    'loan_output_ratio': [],
+}
+
+avg_inflation = sum(self.McountryInflation[c] for c in self.Lcountry) / len(self.Lcountry)
+self._metric_series['inflation'].append(avg_inflation)
+
+mean_price = price_sum_total / price_weight_total
+variance_price = price_sq_sum_total / price_weight_total - (mean_price ** 2)
+price_dispersion = math.sqrt(max(variance_price, 0.0))
+self._metric_series['price_dispersion'].append(price_dispersion)
+
+mean_wage = wage_sum_total / wage_weight_total
+variance_wage = wage_sq_sum_total / wage_weight_total - (mean_wage ** 2)
+wage_dispersion = math.sqrt(max(variance_wage, 0.0))
+self._metric_series['wage_dispersion'].append(wage_dispersion)
+
+fill_rate_value = 1.0
+if fill_desired_total > 0:
+    fill_rate_value = fill_employed_total / float(fill_desired_total)
+self._metric_series['fill_rate'].append(fill_rate_value)
+
+self._metric_series['total_credit'].append(credit_total)
+total_output = totalY
+if total_output > 0:
+    ratio = credit_total / float(total_output)
+else:
+    ratio = 0.0
+self._metric_series['loan_output_ratio'].append(ratio)
+
+avg_spread = spread_weighted_sum / float(spread_loan_sum) if spread_loan_sum > 0 else 0.0
+self._metric_series['avg_spread'].append(avg_spread)
+
+core_metrics = {
+    'inflation_volatility': std(self._metric_series['inflation']),
+    'price_dispersion': mean(self._metric_series['price_dispersion']),
+    'avg_spread': mean(self._metric_series['avg_spread']),
+    'loan_output_ratio': mean(self._metric_series['loan_output_ratio']),
+    'wage_dispersion': mean(self._metric_series['wage_dispersion']),
+    'fill_rate': mean(self._metric_series['fill_rate'], default=1.0),
+}
+```
+
+Use the snippet above to cross-check the definitions in the table. Each metric in `data/core_metrics.csv` corresponds directly to the time-aggregated series captured by `self._metric_series`.


### PR DESCRIPTION
## What
- add writer drafts for the Methods model overview and variable dictionary pages so the manuscript has a central reference
- create `docs/methods/index.qmd` as the Methods hub that links out to runtime docs, data artifacts, and the new pages
- reorganise the Quarto navbar under a single “Methods” dropdown and re-render the docs site

## Why
- Issue #20 requires a Methods index that aggregates the Decider/client/fallback documentation along with the new writer pages (#18, #22)

## Artifacts & Pages
- Pages: `docs/methods/index.qmd`, `docs/methods/model_overview.md`, `docs/methods/variables.md`
- Navigation: `docs/_quarto.yml`
- Render: `quarto render docs`

## Evidence
- `docs/methods/index.qmd:10` — Hub landing page with contextual sections and links
- `docs/methods/model_overview.md:10` — Overview page covering agents, timing, and LLM integration
- `docs/methods/variables.md:10` — Metric dictionary with per-metric computation details and guardrails

Closes #20
