### PR TITLE
41 — Insert firm offered-wage hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,9 @@ Run these from the repo root; keep the Decider stub in its own terminal while th
    python2 code/timing.py
    ```
 
-   - Default parameters cover 1001 ticks; for smoke tests temporarily set `Parameter.ncycle = 200` *locally* (do **not** commit) or switch to the demo runner from #19 once it lands.
-   - Aggregates land in `data/`; runtime notes (and future LLM fallback counts) append to `timing.log`.
+- Default parameters cover 1001 ticks; for smoke tests temporarily set `Parameter.ncycle = 200` *locally* (do **not** commit) or switch to the demo runner from #19 once it lands.
+- Aggregates land in `data/`; runtime notes (and future LLM fallback counts) append to `timing.log`.
+- Longer simulation or demo runs should be executed by the operator; ask for handoff before scheduling any extended run.
 
 3. **Render the Quarto docs.**
 

--- a/code/llm_runtime.py
+++ b/code/llm_runtime.py
@@ -68,6 +68,11 @@ def bank_enabled():
     return bool(parameter and parameter.use_llm_bank_credit)
 
 
+def wage_enabled():
+    parameter = get_parameter()
+    return bool(parameter and parameter.use_llm_wage)
+
+
 def log_fallback(block, reason, detail=None):
     _register_fallback(block, reason)
     message = '[LLM %s] fallback: %s' % (block, reason)
@@ -266,6 +271,7 @@ __all__ = [
     'get_parameter',
     'firm_enabled',
     'bank_enabled',
+    'wage_enabled',
     'log_fallback',
     'log_llm_call',
     'reset_counters',

--- a/code/timing.py
+++ b/code/timing.py
@@ -122,6 +122,7 @@ def run_simulation(parameter=None, progress=True):
         reset_llm_counters()
         ensure_llm_counter('firm')
         ensure_llm_counter('bank')
+        ensure_llm_counter('wage')
         # initialization
         printPa.printingPara(para,run)
         ite=Initialize(para.ncountry,para.nconsumer,para.A,para.phi,\
@@ -327,6 +328,13 @@ def run_simulation(parameter=None, progress=True):
             'bank',
             counters_snapshot.get('bank'),
             getattr(para, 'use_llm_bank_credit', False),
+        )
+        _log_llm_counter_line(
+            para,
+            run,
+            'wage',
+            counters_snapshot.get('wage'),
+            getattr(para, 'use_llm_wage', False),
         )
 
 


### PR DESCRIPTION
## What
- add firm wage-offer LLM helpers (payload, guards, clamps) and route `Firm.wageOffered` through the Decider when wage toggle is on
- expose `wage_enabled` in the runtime and log wage counters alongside firm/bank
- document that long demo runs are operator-only via AGENTS.md

## Why
- satisfy M5 acceptance that the firm wage offer (eq. 15) consults the Decider while protecting price-floor compatibility and hiring-shortfall logic

## Testing
- `python2 -c "from code.timing import run_ab_demo; run_ab_demo(run_id=3, ncycle=5, parameter_overrides={'ncountry': 1, 'nconsumer': 20}, llm_overrides={'use_llm_firm_pricing': False, 'use_llm_bank_credit': False, 'use_llm_wage': True}, progress=False)"`

Closes #41