### PR TITLE
43 — Guard wage δ-cap & price floor

### DIFF
--- a/code/consumer.py
+++ b/code/consumer.py
@@ -4,7 +4,13 @@ import csv
 import random
 import math
 
-from llm_runtime import get_client, log_fallback, log_llm_call, wage_enabled
+from llm_runtime import (
+    get_client,
+    get_wage_guard_caps,
+    log_fallback,
+    log_llm_call,
+    wage_enabled,
+)
 
 class Consumer:
       def __init__(self,ide,country,w,beta,folder,name,run,delta,\
@@ -276,8 +282,9 @@ class Consumer:
 
 
       def _wage_guard_caps(self):
+          caps = get_wage_guard_caps() or {}
           try:
-              delta = float(getattr(self, 'deltaLabor', 0.0))
+              delta = float(caps.get('max_wage_step', 0.0))
           except (TypeError, ValueError):
               delta = 0.0
           if delta < 0.0:


### PR DESCRIPTION
## What
- route wage guard presets through the shared LLM runtime helper so worker and firm hooks share δ scaling and custom overrides
- clamp firm wage offers with price-floor awareness, logging `price_floor_guard` and reverting to baseline when the floor binds
- keep worker wage updates on the same cap, logging and clamping steps above δ

## Why
- issue #43 requires wage guards to honour δ and the Caiani price-floor; sharing the helper avoids drift between agents and supports tight/loose presets

## Evidence
- `[LLM wage] counters name=muxSnCo5upsilon20.7polModPolVar0.512 run=0 llm=on calls=593348 fallbacks=34 timeouts=0`

## Tests
- `python2 -m py_compile code/consumer.py code/firm.py code/llm_runtime.py`
- `python2 - <<'PY' ... PY`

Closes #43
