### PR TITLE
46 — Wage A/B Quarto page

### DIFF
--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -37,6 +37,10 @@ The table above is drawn from `data/_examples/sample_metrics.csv`; future Quarto
 
 - [Bank credit A/B comparison](bank_ab.qmd) — embeds Table `@tbl-bank-ab` and Figure `@fig-bank-ab` produced by the 200-tick OFF/ON runs.
 
+## Milestone M5 — Wage bargaining
+
+- [Wage bargaining A/B comparison](wage_ab.qmd) — embeds Table `@tbl-wage-ab` and Figure `@fig-wage-ab` derived from the 200-tick OFF/ON runs.
+
 ## Ethics & scope
 
 {{< include snippets/ethics_scope.md >}}

--- a/docs/prompts/issue-30-writer.md
+++ b/docs/prompts/issue-30-writer.md
@@ -42,7 +42,7 @@ Because the stub currently rejects every firm request, the OFF and ON scenarios 
 ## Core metrics
 The table aggregates inflation volatility and price dispersion for the baseline (`OFF`) and LLM-enabled (`ON`) runs. Values are rounded to two decimals per the manuscript convention.
 
-```{python}
+```python
 #| label: tbl-firm-ab
 #| tbl-cap: "Firm A/B metrics (run 0, 200 ticks)."
 import pandas as pd

--- a/docs/prompts/issue-31-signoff.md
+++ b/docs/prompts/issue-31-signoff.md
@@ -161,7 +161,7 @@ Because the stub currently rejects every firm request, the OFF and ON scenarios 
 ## Core metrics
 The table aggregates inflation volatility and price dispersion for the baseline (`OFF`) and LLM-enabled (`ON`) runs. Values are rounded to two decimals per the manuscript convention.
 
-```{python}
+```python
 #| label: tbl-firm-ab
 #| tbl-cap: "Firm A/B metrics (run 0, 200 ticks)."
 import pandas as pd

--- a/docs/prompts/issue-38-writer.md
+++ b/docs/prompts/issue-38-writer.md
@@ -114,7 +114,7 @@ Because the Decider stub currently returns deterministic fallbacks, the OFF and 
 ## Core metrics
 The table summarises the average spread, loan-to-output ratio, and credit-growth proxy for baseline (`OFF`) versus LLM-enabled (`ON`) runs. Values follow manuscript formatting (two decimals, comma separators for large magnitudes).
 
-```{python}
+```python
 #| label: tbl-bank-ab
 #| tbl-cap: "Bank A/B metrics (run 0, 200 ticks)."
 ...

--- a/docs/wage_ab.qmd
+++ b/docs/wage_ab.qmd
@@ -1,0 +1,46 @@
+---
+title: "Wage A/B Comparison"
+date: last-modified
+format:
+  html:
+    toc: true
+    toc-depth: 2
+---
+
+# Overview
+This page reports the wage bargaining experiment for Milestone M5. Both runs use `run_id = 0` over a 200-tick horizon with the Decider stub supplying deterministic responses. The artifacts below come from `python3 tools/generate_wage_ab.py`, which invokes `code/timing.py` to export the wage metrics and series used in the manuscript.
+
+The stub currently preserves baseline behaviour for the OFF leg and applies identical guard-respecting responses for the ON leg, so values remain close but can diverge when guard clamps trigger. We keep the artifacts in place so later prompt work can replace the stub without altering page structure.
+
+## Core metrics
+Table @tbl-wage-ab summarises wage dispersion and vacancy fill rate for baseline (`OFF`) versus LLM-enabled (`ON`) runs. Values are rounded to two decimals to match the manuscript convention.
+
+```{python}
+#| label: tbl-wage-ab
+#| tbl-cap: "Wage A/B metrics (run 0, 200 ticks)."
+import pandas as pd
+from pathlib import Path
+
+source = Path("../data/wage/wage_ab_table.csv")
+df = pd.read_csv(source)
+ordered = (
+    df.pivot(index="scenario", columns="metric", values="value")
+      .reindex(["baseline", "llm_on"])
+      [["wage_dispersion", "fill_rate"]]
+      .rename(columns={
+          "wage_dispersion": "Wage dispersion",
+          "fill_rate": "Vacancy fill rate",
+      })
+)
+formatted = ordered.applymap(lambda x: f"{x:,.2f}")
+formatted
+```
+
+## Wage-dispersion overlay
+Figure @fig-wage-ab overlays the OFF and ON wage-dispersion series. The OFF path is dashed, the ON path is solid, and the final 50 ticks are shaded to highlight the comparison window used elsewhere in the manuscript.
+
+![Wage dispersion overlay (OFF dashed, ON solid; final 50 ticks shaded)](../figs/wage/wage_ab_overlay.png){#fig-wage-ab}
+
+## Notes
+- Artifact paths: `data/wage/wage_ab_table.csv`, `figs/wage/wage_ab_overlay.png`.
+- Stub behaviour keeps OFF/ON decisions largely aligned; expect richer divergences once live prompts replace the stub.


### PR DESCRIPTION
## What
- add `docs/wage_ab.qmd` with the wage A/B table (`@tbl-wage-ab`) and overlay (`@fig-wage-ab`), mirroring the firm/bank page structure
- link the new page from `docs/index.qmd` under a Milestone M5 section
- normalise writer/signoff briefs to use literal ```python fences so Quarto renders without trying to execute code in `.md` prompts

## Why
- Issue #46 requires the wage A/B artifacts from #45 to appear in the manuscript site with proper cross-references.

## Pages
- `docs/wage_ab.qmd`
- `docs/index.qmd`

## Evidence
- `quarto render docs`

Closes #46.
