### PR TITLE
120 — Firm live prompt & schema

### DIFF
--- a/docs/methods/decider.md
+++ b/docs/methods/decider.md
@@ -45,8 +45,9 @@ python3 tools/decider/server.py \
 
 - `--mode live` switches the handler to the OpenRouter adapter; the default remains `stub` so accidental runs stay cost-free.
 - Provide the primary model slug via the flag or the `OPENROUTER_MODEL_PRIMARY` environment variable. The fallback slug is optional but recommended.
-- The server verifies both slugs with `/api/v1/models` on startup and logs the selected provider, prompt/response token counts, elapsed time, and any `why_code` the model returns.
+- The server verifies both slugs with `/api/v1/models` on startup and logs the selected provider, prompt/response token counts, elapsed time, and any `why` codes the model returns.
 - Live requests honour the same `--deadline-ms` budget; the adapter subtracts a small buffer before calling OpenRouter so the overall request still respects the server deadline. Any timeout or schema violation is surfaced back to the simulation as an HTTP error, triggering the baseline fallback path.
+- Firm decisions follow a strict schema: `direction ∈ {raise, hold, cut}`, `price_step`/`expectation_bias` within ±0.04, a `why` array drawn from enumerated codes (`baseline_guard`, `inventory_pressure`, `demand_softening`, etc.), and `confidence ∈ [0,1]`. The server validates these fields before applying guard clamps so malformed replies fail fast.
 
 > **Guardrail:** keep the stub workflow for day-to-day smoke tests. Only start live mode when you explicitly want to hit OpenRouter and have confirmed your API key, model slugs, and run budget.
 

--- a/tools/decider/prompts/firm_live.json
+++ b/tools/decider/prompts/firm_live.json
@@ -1,0 +1,5 @@
+{
+  "system": "You are the firm pricing strategist for the Caiani AB-SFC simulation. Always obey the guard rails supplied in the payload. Output ONLY valid JSON conforming to the provided schema. Never include prose outside JSON.",
+  "user_template": "The simulation captured the following firm state, baseline heuristic, and guard limits (JSON):\n{payload_json}\n\nDecide whether to raise, hold, or cut the price. Honour max_price_step, expectation bias caps, and the price floor. Choose one or more why-codes that explain the move (see schema enum). Confidence should be a probability in [0,1]. Return JSON only.",
+  "response_schema": "firm_live_response.schema.json"
+}

--- a/tools/decider/schemas/firm_live_response.schema.json
+++ b/tools/decider/schemas/firm_live_response.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Firm live decision response",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "direction",
+    "price_step",
+    "expectation_bias",
+    "why",
+    "confidence"
+  ],
+  "properties": {
+    "direction": {
+      "type": "string",
+      "enum": ["raise", "hold", "cut"]
+    },
+    "price_step": {
+      "type": "number",
+      "minimum": -0.04,
+      "maximum": 0.04
+    },
+    "expectation_bias": {
+      "type": "number",
+      "minimum": -0.04,
+      "maximum": 0.04
+    },
+    "why": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 3,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "baseline_guard",
+          "demand_softening",
+          "demand_spike",
+          "cost_push",
+          "credit_constraint",
+          "inventory_pressure",
+          "llm_uncertain"
+        ]
+      }
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "comment": {
+      "type": "string",
+      "maxLength": 280
+    }
+  }
+}


### PR DESCRIPTION
## What
- add architect-style firm prompt (`tools/decider/prompts/firm_live.json`) and JSON schema (`tools/decider/schemas/firm_live_response.schema.json`) with direction/step caps, why-code enums, and confidence
- wire the Decider server to load the prompt/schema, validate live responses via jsonschema, and log why arrays + confidence before caching
- extend unit tests to cover valid/invalid firm decisions and document the schema expectations in `docs/methods/decider.md`

## Why
- milestone M6 requires firm live mode to enforce structured outputs and why-code telemetry before guard clamps

## Testing
- python3 -m unittest discover -v

Closes #120
