### PR TITLE
49 — A/B overlay overview

### DIFF
--- a/docs/ab_overview.qmd
+++ b/docs/ab_overview.qmd
@@ -1,0 +1,31 @@
+---
+title: "A/B Overlay Overview"
+date: last-modified
+format:
+  html:
+    toc: true
+    toc-depth: 2
+---
+
+# Snapshot
+The short-horizon A/B experiments share a common configuration: `run_id = 0`, `ncycle = 200`, and the deterministic Decider stub. Each overlay compares the legacy baseline (OFF) against the guard-railed LLM path (ON) with OFF rendered as a dashed line, ON as a solid line, and the final 50 ticks shaded for manuscript alignment.
+
+## Overlays at a glance
+All three overlays originate from the runner outputs documented on the block-specific pages. The captions restate the run settings and call out the detailed figure identifiers (`fig-firm-ab`, `fig-bank-ab`, `fig-wage-ab`) so cross-references in the manuscript remain stable.
+
+::: {.layout-ncol=1}
+![Firm price-dispersion overlay (OFF dashed, ON solid; final 50 ticks shaded). Run generated with `run_id=0`, `ncycle=200`. Detailed breakdown: [fig-firm-ab](firm_ab.qmd#fig-firm-ab).](../figs/firm/firm_ab_overlay.png){#fig-ab-overview-firm}
+
+![Bank average-spread overlay (OFF dashed, ON solid; final 50 ticks shaded). Run generated with `run_id=0`, `ncycle=200`. Detailed breakdown: [fig-bank-ab](bank_ab.qmd#fig-bank-ab).](../figs/bank/bank_ab_overlay.png){#fig-ab-overview-bank}
+
+![Wage dispersion overlay (OFF dashed, ON solid; final 50 ticks shaded). Run generated with `run_id=0`, `ncycle=200`. Detailed breakdown: [fig-wage-ab](wage_ab.qmd#fig-wage-ab).](../figs/wage/wage_ab_overlay.png){#fig-ab-overview-wage}
+:::
+
+## Detailed pages
+For tables, counter snippets, and notes, consult the individual A/B write-ups:
+
+- [Firm A/B comparison](firm_ab.qmd)
+- [Bank A/B comparison](bank_ab.qmd)
+- [Wage A/B comparison](wage_ab.qmd)
+
+Each page includes the core metrics tables (`tbl-firm-ab`, `tbl-bank-ab`, `tbl-wage-ab`) and reiterates the OFF/ON artifact paths documented in `code/timing.py`.

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -41,6 +41,10 @@ The table above is drawn from `data/_examples/sample_metrics.csv`; future Quarto
 
 - [Wage bargaining A/B comparison](wage_ab.qmd) — embeds Table `@tbl-wage-ab` and Figure `@fig-wage-ab` derived from the 200-tick OFF/ON runs.
 
+## Milestone M6 — A/B runner & overlays
+
+- [A/B overlay overview](ab_overview.qmd) — collects the firm, bank, and wage overlays (OFF dashed, ON solid, final 50 ticks shaded) produced from the `run_id=0`, `ncycle=200` runs.
+
 ## Ethics & scope
 
 {{< include snippets/ethics_scope.md >}}


### PR DESCRIPTION
## What
- add docs/ab_overview.qmd to collect the firm/bank/wage overlays with captions that restate the run settings and reference the block figure IDs
- link the overview page from docs/index.qmd under a new Milestone M6 section

## Why
- satisfy M6-02 requirement for a consolidated overlay page that keeps manuscript references stable while the stub data is in place

## Artifact & Page List
- docs/ab_overview.qmd
- docs/index.qmd
- docs/_site/ab_overview.html

## Testing
- quarto render docs

Closes #49