### PR TITLE
52 — Reference A/B tables by ID

### DIFF
--- a/docs/bank_ab.qmd
+++ b/docs/bank_ab.qmd
@@ -13,7 +13,7 @@ This page documents the bank credit & spreads experiment for Milestone M4. Both 
 Because the Decider stub currently returns deterministic fallbacks, the OFF and ON scenarios remain identical. We publish the artifacts now so prompt work can later drop in differentiated behaviour without restructuring the page.
 
 ## Core metrics
-The table summarises the average spread, loan-to-output ratio, and credit-growth proxy for baseline (`OFF`) versus LLM-enabled (`ON`) runs. Values follow manuscript formatting (two decimals, comma separators for large magnitudes).
+Table @tbl-bank-ab summarises the average spread, loan-to-output ratio, and credit-growth proxy for baseline (`OFF`) versus LLM-enabled (`ON`) runs. Values follow manuscript formatting (two decimals, comma separators for large magnitudes).
 
 ```{python}
 #| label: tbl-bank-ab

--- a/docs/firm_ab.qmd
+++ b/docs/firm_ab.qmd
@@ -13,7 +13,7 @@ This page tracks the firm pricing & expectations experiment for Milestone M3. Bo
 Because the stub currently rejects every firm request, the OFF and ON scenarios are identical. We keep the artifacts in place so later prompt work can drop in updated values without changing the page structure.
 
 ## Core metrics
-The table aggregates inflation volatility and price dispersion for the baseline (`OFF`) and LLM-enabled (`ON`) runs. Values are rounded to two decimals per the manuscript convention.
+Table @tbl-firm-ab aggregates inflation volatility and price dispersion for the baseline (`OFF`) and LLM-enabled (`ON`) runs. Values are rounded to two decimals per the manuscript convention.
 
 ```{python}
 #| label: tbl-firm-ab


### PR DESCRIPTION
## What
- update docs/firm_ab.qmd and docs/bank_ab.qmd to call their metric tables by Quarto ID (Table @tbl-firm-ab / Table @tbl-bank-ab) in the narrative text

## Why
- keep A/B pages aligned with the manuscript cross-referencing conventions from M0-04 and satisfy M6-05 acceptance criteria

## Artifact & Page List
- docs/firm_ab.qmd
- docs/bank_ab.qmd
- docs/_site/firm_ab.html
- docs/_site/bank_ab.html

## Testing
- quarto render docs

Closes #52