### PR TITLE
69 — Add stub A/B overlay narrative

### DIFF
--- a/docs/main.qmd
+++ b/docs/main.qmd
@@ -66,6 +66,26 @@ baseline
 A/B results will add comparative columns once Issue #69 (Results integration) lands. For now, the baseline run (seeded by PR #108) establishes the canonical reference values.
 :::
 
+## A/B overlays (short-horizon stub) {#sec-results-ab-overlays}
+
+We assess the short-horizon (200 ticks) impact of enabling the LLM hooks by comparing the baseline (OFF) against the LLM-augmented (ON) configuration. Both legs reuse the same seed (`run_id = 0`), while the ON leg calls the Decider in deterministic stub mode (Temperature = 0). This pass validates the integration pipeline and isolates the effect of baseline guardrails—0.04 caps on price/wage steps and expectation bias, the unit-cost price floor, and spread clamps—before we introduce live prompts. In the overlay figures the ON trajectory is rendered as a solid line, the OFF trajectory as a dashed line, and the final 50 periods are shaded grey (see `firm_ab.qmd#fig-firm-ab`, `bank_ab.qmd#fig-bank-ab`, and `wage_ab.qmd#fig-wage-ab`).
+
+### Firm pricing and expectations (RQ1)
+
+Figure `firm_ab.qmd#fig-firm-ab` collapses to a single trajectory: the deterministic stub rejects every firm pricing request, so inflation volatility and price dispersion are identical across OFF and ON (Table `firm_ab.qmd#tbl-firm-ab`). This "stub parity" outcome is expected given equations 12–14 still rely on the baseline heuristic, and it confirms that the A/B harness keeps the legacy behaviour intact. We expect measurable divergence on RQ1—changes in inflation volatility or price dispersion—only after live, context-aware prompts replace the stub.
+
+### Bank credit and spreads (RQ2)
+
+Bank credit overlays behave the same way. Figure `bank_ab.qmd#fig-bank-ab` shows complete overlap between OFF and ON, while Table `bank_ab.qmd#tbl-bank-ab` reports matching average spreads and loan-to-output ratios. The bank stub returns deterministic fallbacks that mirror the baseline leverage rule (equations 26–27), so no qualitative "soft information" is present yet. This overlay therefore functions as a control; RQ2 will only be addressed once live prompts simulate narrative lending decisions.
+
+### Wage bargaining (RQ3)
+
+Wage bargaining is the only block that diverges under the stub. Figure `wage_ab.qmd#fig-wage-ab` shows the ON leg flattening relative to the adaptive baseline, and Table `wage_ab.qmd#tbl-wage-ab` records a collapse in wage dispersion (0.002 vs 0.144) alongside a higher vacancy fill rate (0.55 vs 0.35). This shift is driven by guard clamping rather than learned heuristics: the stub emits a zero step and the guards enforce it, while the baseline continues the standard drift from equations 1 and 15. The result highlights how the guard stack alone can stabilise the ON path ahead of the live prompt work.
+
+### Outlook
+
+These short-horizon stubbed runs verify the A/B pipeline: parity in the firm and bank overlays shows the guard stack holding baseline behaviour, while the wage overlay demonstrates the conservative effect of the clamps. We will revisit all three overlays during M6-LIVE once OpenRouter prompts introduce genuine behavioural divergence.
+
 ## Horizon stability evidence {#sec-results-hsc}
 
 - Horizon Stability Check (HSC) OFF run: see `docs/stability.qmd` for full commentary.


### PR DESCRIPTION
## What
- add a Results subsection describing the short-horizon stub A/B overlays, including firm, bank, and wage paragraphs plus an outlook note that flags future live runs

## Why
- integrate the writer’s copy from Issue #53 so the manuscript records the current stub baselines before live prompts land

## Artifact & Page List
- docs/main.qmd
- docs/_site/main.html

## Testing
- quarto render docs (warnings remain for cross-doc crossrefs in prompts; unchanged behaviour)

Closes #53