### PR TITLE
58 — Experiment pages for A/B/C

### DIFF
--- a/docs/exp_A.qmd
+++ b/docs/exp_A.qmd
@@ -1,0 +1,54 @@
+---
+title: "Experiment A — Wage Acceleration (Country 0)"
+date: last-modified
+format:
+  html:
+    toc: true
+    toc-depth: 2
+---
+
+# Overview
+Experiment A lowers the wage-adjustment parameter `upsilon` for **country 0** to 80 % of its baseline value starting at tick `t0 = 50`. Both scenarios use `run_id = 0` and run for `ncycle = 250` ticks with the Decider stub providing deterministic responses. The helper script `python3 tools/generate_exp_a_demo.py` produces the metrics in `data/expA_demo/` and the overlay in `figs/expA_demo/`.
+
+::: {.callout-note}
+The ON leg enables the wage hook only; firm pricing and bank credit remain on the baseline path so the experiment isolates the wage-policy change for country 0.
+:::
+
+## Core metrics
+Table @tbl-exp-a summarises wage dispersion and vacancy fill rates for the baseline (`OFF`) and policy (`ON`) runs. Values are rounded to two decimals following the manuscript convention.
+
+```{python}
+#| label: tbl-exp-a
+#| tbl-cap: "Experiment A metrics (run 0, 250 ticks)."
+import pandas as pd
+from pathlib import Path
+
+source = Path("../data/expA_demo/expA_metrics.csv")
+df = pd.read_csv(source)
+ordered = (
+    df.pivot(index="scenario", columns="metric", values="value")
+      .reindex(["baseline", "llm_on"])
+      [["wage_dispersion", "fill_rate"]]
+      .rename(columns={
+          "wage_dispersion": "Wage dispersion",
+          "fill_rate": "Fill rate",
+      })
+)
+formatted = ordered.applymap(lambda x: f"{x:,.2f}")
+scenario_labels = {
+    "baseline": "Baseline (OFF)",
+    "llm_on": "LLM ON (stub)",
+}
+formatted.index = [scenario_labels.get(idx, idx) for idx in formatted.index]
+formatted
+```
+
+## Wage-dispersion overlay
+Figure @fig-exp-a overlays the OFF and ON wage-dispersion series. OFF remains dashed, ON is solid, and the final 50 ticks are shaded to highlight the comparison window used throughout the manuscript. A vertical marker at tick 50 indicates when the policy switch occurs.
+
+![Experiment A — wage dispersion overlay (OFF dashed, ON solid; final 50 ticks shaded)](../figs/expA_demo/expA_wage_dispersion_overlay.png){#fig-exp-a}
+
+## Notes
+- Artifact paths: `data/expA_demo/expA_metrics.csv`, `data/expA_demo/expA_wage_dispersion_series.csv`, `figs/expA_demo/expA_wage_dispersion_overlay.png`.
+- Generator: `python3 tools/generate_exp_a_demo.py` (runs with `RUN_ID=0`, `NCYCLE=250`, `t0=50`).
+- The deterministic stub clamps the ON path, driving wage dispersion to zero; live prompt work (M6-LIVE) will introduce heterogeneous responses.

--- a/docs/exp_B.qmd
+++ b/docs/exp_B.qmd
@@ -1,0 +1,54 @@
+---
+title: "Experiment B — Wage Moderation (Country 0)"
+date: last-modified
+format:
+  html:
+    toc: true
+    toc-depth: 2
+---
+
+# Overview
+Experiment B raises the wage-adjustment parameter `upsilon` for **country 0** to 120 % of its baseline value at tick `t0 = 50`. Both legs share `run_id = 0` and `ncycle = 250`; the Decider stub remains deterministic. Metrics and overlays are generated with `python3 tools/generate_exp_b_demo.py`, which writes artifacts to `data/expB_demo/` and `figs/expB_demo/`.
+
+::: {.callout-note}
+Only the wage hook for country 0 is modified. Firm pricing and bank credit continue to follow the baseline rules so the effects stem solely from the higher wage responsiveness.
+:::
+
+## Core metrics
+Table @tbl-exp-b reports wage dispersion and vacancy fill rates for the OFF and policy-on runs. Values are rendered to two decimals per the project standard.
+
+```{python}
+#| label: tbl-exp-b
+#| tbl-cap: "Experiment B metrics (run 0, 250 ticks)."
+import pandas as pd
+from pathlib import Path
+
+source = Path("../data/expB_demo/expB_metrics.csv")
+df = pd.read_csv(source)
+ordered = (
+    df.pivot(index="scenario", columns="metric", values="value")
+      .reindex(["baseline", "policy_high"])
+      [["wage_dispersion", "fill_rate"]]
+      .rename(columns={
+          "wage_dispersion": "Wage dispersion",
+          "fill_rate": "Fill rate",
+      })
+)
+formatted = ordered.applymap(lambda x: f"{x:,.2f}")
+scenario_labels = {
+    "baseline": "Baseline (OFF)",
+    "policy_high": "Policy ON (stub)",
+}
+formatted.index = [scenario_labels.get(idx, idx) for idx in formatted.index]
+formatted
+```
+
+## Wage-dispersion overlay
+Figure @fig-exp-b displays the OFF and ON wage-dispersion series with the usual styling (OFF dashed, ON solid, final 50 ticks shaded). Tick 50 marks the point where the higher `upsilon` takes effect.
+
+![Experiment B — wage dispersion overlay (OFF dashed, ON solid; final 50 ticks shaded)](../figs/expB_demo/expB_wage_dispersion_overlay.png){#fig-exp-b}
+
+## Notes
+- Artifact paths: `data/expB_demo/expB_metrics.csv`, `data/expB_demo/expB_wage_dispersion_series.csv`, `figs/expB_demo/expB_wage_dispersion_overlay.png`.
+- Generator: `python3 tools/generate_exp_b_demo.py` (`RUN_ID=0`, `NCYCLE=250`, `t0=50`).
+- Stub behaviour dampens the ON leg to the guard rails; live prompts will inject heterogeneity once M6-LIVE scenarios run.

--- a/docs/exp_C.qmd
+++ b/docs/exp_C.qmd
@@ -1,0 +1,54 @@
+---
+title: "Experiment C — Coordinated Wage Moderation"
+date: last-modified
+format:
+  html:
+    toc: true
+    toc-depth: 2
+---
+
+# Overview
+Experiment C applies a coordinated wage-policy shift across **all countries**, reducing `upsilon` to 90 % of baseline at tick `t0 = 50`. The runs share `run_id = 0`, `ncycle = 250`, and use the deterministic Decider stub. Artifacts originate from `python3 tools/generate_exp_c_demo.py`, which saves outputs under `data/expC_demo/` and `figs/expC_demo/`.
+
+::: {.callout-note}
+This coordinated scenario highlights how the guard rails behave when every country tightens wage adjustments simultaneously. Firms and banks remain on the baseline logic; only the wage hook changes.
+:::
+
+## Core metrics
+Table @tbl-exp-c lists the resulting wage dispersion and vacancy fill rates. Figures are rounded to two decimals.
+
+```{python}
+#| label: tbl-exp-c
+#| tbl-cap: "Experiment C metrics (run 0, 250 ticks)."
+import pandas as pd
+from pathlib import Path
+
+source = Path("../data/expC_demo/expC_metrics.csv")
+df = pd.read_csv(source)
+ordered = (
+    df.pivot(index="scenario", columns="metric", values="value")
+      .reindex(["baseline", "policy_low"])
+      [["wage_dispersion", "fill_rate"]]
+      .rename(columns={
+          "wage_dispersion": "Wage dispersion",
+          "fill_rate": "Fill rate",
+      })
+)
+formatted = ordered.applymap(lambda x: f"{x:,.2f}")
+scenario_labels = {
+    "baseline": "Baseline (OFF)",
+    "policy_low": "Policy ON (stub)",
+}
+formatted.index = [scenario_labels.get(idx, idx) for idx in formatted.index]
+formatted
+```
+
+## Wage-dispersion overlay
+Figure @fig-exp-c overlays the wage-dispersion series for the OFF and policy-on runs. OFF remains dashed, ON is solid, the final 50 ticks are shaded, and the vertical line at tick 50 indicates when the reduction takes effect.
+
+![Experiment C — wage dispersion overlay (OFF dashed, ON solid; final 50 ticks shaded)](../figs/expC_demo/expC_wage_dispersion_overlay.png){#fig-exp-c}
+
+## Notes
+- Artifact paths: `data/expC_demo/expC_metrics.csv`, `data/expC_demo/expC_wage_dispersion_series.csv`, `figs/expC_demo/expC_wage_dispersion_overlay.png`.
+- Generator: `python3 tools/generate_exp_c_demo.py` (`RUN_ID=0`, `NCYCLE=250`, `t0=50`).
+- Stub output drives the policy-on dispersion to zero; future live LLM experiments will explore heterogeneous adjustments across the monetary union.

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -46,6 +46,12 @@ The table above is drawn from `data/_examples/sample_metrics.csv`; future Quarto
 - [A/B overlay overview](ab_overview.qmd) — collects the firm, bank, and wage overlays (OFF dashed, ON solid, final 50 ticks shaded) produced from the `run_id=0`, `ncycle=200` runs.
 - [How to reproduce A/B overlays](howto_ab.qmd) — three-step checklist (stub, `run_ab_demo`, Quarto render) for regenerating the OFF→ON artifacts.
 
+## Milestone M7 — Experiments A/B/C (small horizon)
+
+- [Experiment A — Wage Acceleration (Country 0)](exp_A.qmd) — `run_id=0`, `ncycle=250`; `python3 tools/generate_exp_a_demo.py` drops country 0 `upsilon` to 80 % at `t0=50` and exports `data/expA_demo/*`, `figs/expA_demo/*`.
+- [Experiment B — Wage Moderation (Country 0)](exp_B.qmd) — `run_id=0`, `ncycle=250`; `python3 tools/generate_exp_b_demo.py` lifts country 0 `upsilon` to 120 % at `t0=50` and exports `data/expB_demo/*`, `figs/expB_demo/*`.
+- [Experiment C — Coordinated Wage Moderation](exp_C.qmd) — `run_id=0`, `ncycle=250`; `python3 tools/generate_exp_c_demo.py` lowers all-country `upsilon` to 90 % at `t0=50` and exports `data/expC_demo/*`, `figs/expC_demo/*`.
+
 ## Appendices
 
 - [Appendix B — JSON response schemas](appendix_schemas.qmd) — field-by-field summary of the firm, bank, and wage live-mode response schemas enforced by the Decider.


### PR DESCRIPTION
What
- add `docs/exp_A.qmd`, `docs/exp_B.qmd`, and `docs/exp_C.qmd` describing the Experiment A/B/C demo runs (run_id=0, ncycle=250) with metric tables and wage-dispersion overlays referencing the generated CSV/PNG artifacts
- update `docs/index.qmd` to surface the new experiment pages and point to the associated generator scripts and artifact folders

Why
- documents the small-horizon wage experiments delivered in M7 so readers can inspect the scenarios (country 0 acceleration/moderation and union-wide moderation) directly from the Quarto site

Artifacts
- `docs/_site/exp_A.html`
- `docs/_site/exp_B.html`
- `docs/_site/exp_C.html`

Testing
- `quarto render docs` (completes with existing cross-ref warnings from legacy prompt briefs)
